### PR TITLE
style:layout-footer 레이아웃 및 컬러 자간 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@tanstack/react-query": "^5.80.7",
         "axios": "^1.10.0",
         "lucide-react": "^0.515.0",
+        "pretendard": "^1.3.9",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-router": "^7.6.2",
@@ -4941,6 +4942,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/pretendard": {
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/pretendard/-/pretendard-1.3.9.tgz",
+      "integrity": "sha512-PaQAADyLY5v4kYFwkpSJHbSSYIkiriY/1xXw75TKoZ9UQQqeU+tvP05yTdZAWibiIYoo8ZKtRv8PM7w0IaywSw==",
+      "license": "OFL-1.1"
     },
     "node_modules/prettier": {
       "version": "3.6.2",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@tanstack/react-query": "^5.80.7",
     "axios": "^1.10.0",
     "lucide-react": "^0.515.0",
+    "pretendard": "^1.3.9",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router": "^7.6.2",

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -1,17 +1,55 @@
 // src/components/layout/Footer.tsx
+
 export default function Footer() {
   return (
-    <footer className="mt-20 border-t border-white/10 bg-[#222222] text-neutral-200">
-      <div className="mx-auto max-w-6xl px-6 py-14">
-        {/* 상단 영역 */}
-        <div className="flex flex-col gap-10 md:flex-row md:items-start md:justify-between">
-          {/* 좌측: 브랜드 + 메뉴 */}
-          <div className="space-y-6">
-            <h2 className="text-2xl font-semibold tracking-tight">
-              OZ. 오즈코딩스쿨
-            </h2>
+    <footer className="w-full bg-[#222222]">
+      <div className="mx-auto max-w-[1920px] px-[360px] pt-[80px] pb-[80px]">
+        {/* 피그마 기준: footer content width = 1200 */}
+        <div className="w-[1200px]">
+          {/* ======================
+              TOP (logo + camp list)
+              ====================== */}
+          <div className="h-[150.71px] w-[159px]">
+            {/* OZ logo: 159 x 24 (인라인 SVG) */}
+            <div className="h-[24px] w-[159px]">
+              <svg
+                width="159"
+                height="24"
+                viewBox="0 0 159 24"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+                xmlnsXlink="http://www.w3.org/1999/xlink"
+              >
+                <rect
+                  width="159"
+                  height="23.7105"
+                  fill="url(#pattern0_91_14382)"
+                />
+                <defs>
+                  <pattern
+                    id="pattern0_91_14382"
+                    patternContentUnits="objectBoundingBox"
+                    width="1"
+                    height="1"
+                  >
+                    <use
+                      xlinkHref="#image0_91_14382"
+                      transform="scale(0.00438596 0.0294118)"
+                    />
+                  </pattern>
+                  <image
+                    id="image0_91_14382"
+                    width="228"
+                    height="34"
+                    preserveAspectRatio="none"
+                    xlinkHref="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAOQAAAAiCAYAAABP5nUkAAAACXBIWXMAABYlAAAWJQFJUiTwAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAi1SURBVHgB7ZxNdts2EMdHfV10V/cEQU4Q9QSRT1D3BKF33dk5gZUT2Nl10yf6BHZOIPUEdk5A3kDOru1min8A2hQ0AEGQVOiYv/f4KJH45mAwGIAkmpiYGA0zmpgYAcy80KcL5/LH2Wx2Sy+IH2kCwqD0STmXH7Qw3NPEoVD6WDjXrmlEWKWxon4ptZwdV39eZIfUDXukT5k+ftPHXB9HnnA4bcgIxkY3XEnx6c9pGLyKwiqWBfUPhGYj5Ic6nlAaVzrNBxoIXbY17bfFqc4zp24oGpAX1yH1gzrTpyV5OqHAwh6Iu9QP9ENEHAjqmoZho49jzz1F/WvwKs+NcB31vKA0cn0M1iGfK40d0mrBurYvyWjMkp4RdtSCsKZqdLDU6WT6fPzc6j/RC1AgG+qG1yIDYoe0pg9Gkoz85lypTxgtvKacNRsUpYF0T6k/fJ0RjQwT8DPtauw3ZEZGt/5KH2tdt1+HNLkmOqOEa7FWkYidKhxTB7TcFNSmQ+oIl/p0Ts0oMkJe6jgfPLa5ovQOqagn7KgmdUYolOBcxsa9cMqj7LX3nmilTTvEKzIKrw7K8bEhXtlwL8akbgLKOFV40SaNzrAhLQyPkw7AZ3BFaWmiPfDMQ+1y1HBfUaxcI0N93HE6F0KaBafT2xzMU46sRXylj62QRrLGRf5CelsaAUJ7rT3hpDosKAFPWhkloONdsMy24zMbgrt6Hj/UfmO06+IZxPwqZmQ9KGwERDmX8zbeNqvNpZEro3TeCteOOFGge0bRM4XN6Jh5bqMzdpHRkvpnxzr7arKy36SrR6rMkNCk9EKndduTOVJSP0hl/Zvak9O+R1FRAg1C8466Ow5eMu70Yu++bv+NtIwTwX0t7Qfa7Uz1/2Xt+pfadcjimZPml/qfag55ESjAe7fwtgNf0r6wV3Z25YxpmgAjDUkRlNTPXKgq05jSAaGlAphu120Fxppide3/ygmiar+luY4iP1/oGcBm2pQ5l9EZ3LqudNjWnnId/nfqgLV+3A65M9/+0XYuJcQvybj3H4SC5ToeEsLcwq3sib6HTvwQqjCb9UDfqHza46S/FK6lmObzyLSDeITGJUlgKH1NsIlRzG198JPDRTJH4WSC1bGoXVNkPOWnTYrPdqIF9cMb6ZrOY2l/PyDDG89kU1EDSMgT96Qhns9JwrXC9QIbZ5Wb1zamfk4ahVDWVh2bZWcDynLluZ61TL/gYVh68hMdMWyeb/2Y62Nh753r45KN3BVV2pzo1LHpFp5yX9kwKhBmxQFZYL+MD0GBDCXPapSHk42gSlw1xCm8BRoAlhsVZVARcZWnje5a5A+hWXvqfG7D+O6vOLLjs1+5SmxtGxQ277XNa+0ro5Bfxt1ZBdLKPPlChs7Z32bgzokDpbANlYMFhxofuENiDik97M8UAcxSNhsElHPr50A036QbpnGnRdcAUBDvaH8tsdDl3+jzJzK2fDUxV/bAutWC9s1yhAnOJ9h09pNaGhJYv62UF9KDInSfR0ZmXnlvyxlySGDP7WeSHQzV+aFh3fVcKG9Jw/FLbEDbpjGbTdAOO0oEi/o6PuTrxhM/I9PO+J33vCklHk9PXbaIXwjxV56wZwHtMOiSCYfNljYETUk2o+E2Ip2lEBeaP+c4+nQy1csgmc9zT9g+Rsh1IK1MyHMdSAvtHpQjNnKw5jBZLfwR75vgvkOqw1WL+AojpOSFekXxRAkGG+229NzOayPFIMBBwkZDLsmMlilsyHid7wP5bHQ+UptWlGScVhshLuLhoeJeyH2ft922x2YH1tzJT7JI3gjl8tU3tLezPkqDyv1f1s5lwvZDeN8XwvWcjMVRhiLb+8cs78AiW6a8Fv6xHmyUYEjepbowNbBTZpZHjaj5ke3VEksnXHDeyC0cLH3AZhRrM99ac4Ojyklf0pTQ3ktuMbLZdAohLUUtYWFU8IRzR/fouXIXuN0ccl2VrW2bCmlhVSCv1TsLhI21XloRm8kiojKrmLhsvGqcms9QsFEU6JySmbZi87CSHjY/OUyuutaRjUMCTgwokSUlwBEdkmUn3S11xJYfbZk5B9p+bsMo+79++F5sUDyAyc4NzjM+UIdceMIVHHYHv/PE2zrhQvPGJY0ATxtk9B3BcR0Sgo4RZ2XD36W0A+96QWPm02zDZjRi+AAdcmYzwnKDEspQkrHZbytbn41mql7ylXj0ULHp0DB5JG3W6Kmk2tvxf/xUKPfmn/+8LqkH2Ixg7lJPH2+XjwYW3qDX9ZtRz7Ax7eHUSx3BSjLz9M4jc9/Yus2pG663f+c5VFvnsJvhRoiMiGjcFZvljaZJLcLUt7zdBMLjetN6Z052G95//84KIa/XNDEarMDeUDcU0sBoqeX0msbFhiJeLWsALxUo382vHRLaSDcA3mY4CySkqJn3jpdrENf8xPiw1tClcAuWEDpWSU/eVQDZQByMOJKQYu79aWQvgV9Ruoc+iscXlHXFz605e0ZpnI7JzGDBzR9AUhyY+0Y3PpYQ2KyBpbZfCli2qKYQTSj3AnvWixu49mxMmAt5QB5OYzoVm91d9XqgXhhx81qYLl+gaEvpWRYalJ0vBthOWZJpGEVxIHzjJt1vAARkQemkzBUqrX9IkGdGaWTUHt+ra1J7tRnh0HldxaKE/4q+Y/Y+4YEFejau7gWZBpIaGo0MW7rpQ7YIU1I6j1v4Zu4CNEzjxiXXiQNSCtfeUDxvI9McG/BxlNQT4keu7Dwwx8H73xiN/uJc1/fH6vzFatd8mDrj2IBidk1gWFyQnWoOWTr3K9lyX4+q2ND4wb5tRR2wDqwcv3t3e48Fbt7m1Cuz/t7fbAUP+1FmiXufGWrn0JfUD9gGt6QRgXVIGsipM8QS1MQEhHbJ3WjcIP6t4IE2BgCamBgKNjt+ILxFC5ms9voqGil8gA45DZMTg8JmDqno6eNo1buy9bc/Nt/K5G+Drcsg06ARrlJMTExMTEyMiP8BD5Nl8NPTP/8AAAAASUVORK5CYII="
+                  />
+                </defs>
+              </svg>
+            </div>
 
-            <ul className="space-y-3 text-sm text-neutral-300">
+            {/* Camp list: 18px / 140% / -3% / #CECECE */}
+            <ul className="mt-[24px] space-y-[16px] font-[Pretendard] text-[18px] leading-[24px] font-[300] tracking-[-0.03em] text-[#CECECE]">
               <li>
                 <a href="#" className="hover:text-white">
                   초격차캠프
@@ -30,78 +68,81 @@ export default function Footer() {
             </ul>
           </div>
 
-          {/* 우측: 정책 링크 + 아이콘 */}
-          <div className="flex flex-col gap-6 md:items-end">
-            <div className="flex flex-wrap gap-x-6 gap-y-2 text-sm text-neutral-300">
-              <a href="#" className="hover:text-white">
-                개인정보처리방침
-              </a>
-              <a href="#" className="hover:text-white">
-                이용약관
-              </a>
-              <a href="#" className="hover:text-white">
-                멘토링&강사지원
-              </a>
+          {/* ======================
+              Divider (피그마: 1px #707070, padding-top: 40)
+              ====================== */}
+          <div className="mt-[40px] w-[1200px] border-t border-[#707070] pt-[40px]">
+            {/* Policy row: 1200 x 64 */}
+            <div className="flex h-[64px] w-[1200px] items-center justify-between">
+              {/* 정책 링크: 16px / 140% / -3% / #CECECE, width 322, gap 28 */}
+              <div className="flex w-[322px] items-center gap-x-[28px] font-[Pretendard] text-[16px] leading-[22.4px] font-[400] tracking-[-0.03em] text-[#CECECE]">
+                <a href="#" className="hover:text-white">
+                  개인정보처리방침
+                </a>
+                <a href="#" className="hover:text-white">
+                  이용약관
+                </a>
+                <a href="#" className="hover:text-white">
+                  멘토링&강사지원
+                </a>
+              </div>
+
+              {/* Right icons: 132 x 24 (네가 준 SVG 그대로 인라인) */}
+              <div className="flex h-[24px] w-[132px] items-center justify-end">
+                <svg
+                  className="h-[24px] w-[132px]"
+                  viewBox="0 0 132 24"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M12.5482 4C7.83195 4 4 7.1 4 10.9C4 13.3 5.57208 15.4 7.83195 16.7L7.24242 20L10.8779 17.6C11.3691 17.7 11.9587 17.7 12.4499 17.7C17.1662 17.7 20.9981 14.6 20.9981 10.8C21.0964 7.1 17.2645 4 12.5482 4Z"
+                    fill="#BDBDBD"
+                  />
+                  <path
+                    d="M41.7679 9.89258C41.5282 9.89258 41.3152 9.98703 41.1554 10.1624C40.9822 10.3379 40.9023 10.5537 40.9023 10.8101C40.9023 11.0665 40.9822 11.2689 41.1554 11.4578C41.3285 11.6332 41.5282 11.7277 41.7679 11.7277C42.0076 11.7277 42.2207 11.6332 42.3938 11.4578C42.567 11.2824 42.6602 11.0665 42.6602 10.8101C42.6602 10.5537 42.567 10.3379 42.3938 10.1624C42.2207 9.97354 42.021 9.89258 41.7679 9.89258Z"
+                    fill="#BDBDBD"
+                  />
+                  <path
+                    d="M49.2386 9.87891C48.9989 9.87891 48.7859 9.97336 48.6261 10.1488C48.4529 10.3242 48.373 10.5401 48.373 10.7964C48.373 11.0528 48.4529 11.2552 48.6261 11.4441C48.7992 11.6195 48.9989 11.714 49.2386 11.714C49.4783 11.714 49.6914 11.6195 49.8645 11.4441C50.0377 11.2687 50.1309 11.0528 50.1309 10.7964C50.1309 10.5401 50.0377 10.3377 49.8645 10.1488C49.7047 9.95987 49.4917 9.87891 49.2386 9.87891Z"
+                    fill="#BDBDBD"
+                  />
+                  <path
+                    d="M54.2318 9.89258C53.9921 9.89258 53.779 9.98703 53.6192 10.1624C53.4461 10.3379 53.3662 10.5537 53.3662 10.8101C53.3662 11.0665 53.4461 11.2689 53.6192 11.4578C53.7924 11.6332 53.9921 11.7277 54.2318 11.7277C54.4715 11.7277 54.6846 11.6332 54.8577 11.4578C55.0308 11.2824 55.1241 11.0665 55.1241 10.8101C55.1241 10.5537 55.0308 10.3379 54.8577 10.1624C54.6846 9.97354 54.4715 9.89258 54.2318 9.89258Z"
+                    fill="#BDBDBD"
+                  />
+                  <path
+                    d="M56.4431 3.22656H39.5573C38.2655 3.22656 37.2002 4.30602 37.2002 5.61487V15.2895C37.2002 16.5984 38.2655 17.6778 39.5573 17.6778H46.1891C46.1891 17.6778 47.4675 21.2266 47.9336 21.2266C48.3997 21.2266 49.7847 17.6778 49.7847 17.6778H56.4431C57.7348 17.6778 58.8002 16.5984 58.8002 15.2895V5.61487C58.8002 4.30602 57.7348 3.22656 56.4431 3.22656Z"
+                    fill="#BDBDBD"
+                  />
+                  <path
+                    d="M84.002 4.25C84.0129 4.25 90.8797 4.25053 92.5977 4.71582C93.5446 4.96807 94.2897 5.71721 94.542 6.67188C94.9999 8.39891 94.9961 12 94.9961 12C94.9961 12.0252 94.9944 15.6073 94.5381 17.3281C94.2858 18.2789 93.5407 19.0281 92.5938 19.2842C90.8781 19.7459 83.998 19.7461 83.998 19.7461C83.9875 19.7461 77.1166 19.7456 75.4023 19.2842C74.4554 19.0319 73.7103 18.2828 73.458 17.3281C73.0017 15.6073 73 12.0252 73 12C73 12 73.0002 8.39887 73.4619 6.66797C73.7142 5.71718 74.4593 4.96804 75.4062 4.71191C77.1218 4.25014 84.002 4.25 84.002 4.25ZM81.751 15.2715L87.502 12L81.751 8.72852V15.2715Z"
+                    fill="#BDBDBD"
+                  />
+                  <path
+                    d="M120 8.83398C118.288 8.83398 116.833 10.2889 116.833 12.0007C116.833 13.7124 118.288 15.1673 120 15.1673C121.711 15.1673 123.166 13.7124 123.166 12.0007C123.166 10.2889 121.711 8.83398 120 8.83398Z"
+                    fill="#BDBDBD"
+                  />
+                  <path
+                    d="M124.059 2.5H116.027C112.918 2.5 110.5 4.91818 110.5 7.94091V15.9727C110.5 19.0818 112.918 21.5 116.027 21.5H124.059C127.082 21.5 129.5 19.0818 129.5 15.9727V7.94091C129.5 4.91818 127.082 2.5 124.059 2.5Z"
+                    fill="#BDBDBD"
+                  />
+                </svg>
+              </div>
             </div>
-            <div className="flex items-center gap-3 text-neutral-400">
-              <svg
-                width="132"
-                height="24"
-                viewBox="0 0 132 24"
-                fill="none"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                {' '}
-                <path
-                  d="M12.5482 4C7.83195 4 4 7.1 4 10.9C4 13.3 5.57208 15.4 7.83195 16.7L7.24242 20L10.8779 17.6C11.3691 17.7 11.9587 17.7 12.4499 17.7C17.1662 17.7 20.9981 14.6 20.9981 10.8C21.0964 7.1 17.2645 4 12.5482 4Z"
-                  fill="#BDBDBD"
-                />{' '}
-                <path
-                  d="M41.7679 9.89258C41.5282 9.89258 41.3152 9.98703 41.1554 10.1624C40.9822 10.3379 40.9023 10.5537 40.9023 10.8101C40.9023 11.0665 40.9822 11.2689 41.1554 11.4578C41.3285 11.6332 41.5282 11.7277 41.7679 11.7277C42.0076 11.7277 42.2207 11.6332 42.3938 11.4578C42.567 11.2824 42.6602 11.0665 42.6602 10.8101C42.6602 10.5537 42.567 10.3379 42.3938 10.1624C42.2207 9.97354 42.021 9.89258 41.7679 9.89258Z"
-                  fill="#BDBDBD"
-                />{' '}
-                <path
-                  d="M49.2386 9.87891C48.9989 9.87891 48.7859 9.97336 48.6261 10.1488C48.4529 10.3242 48.373 10.5401 48.373 10.7964C48.373 11.0528 48.4529 11.2552 48.6261 11.4441C48.7992 11.6195 48.9989 11.714 49.2386 11.714C49.4783 11.714 49.6914 11.6195 49.8645 11.4441C50.0377 11.2687 50.1309 11.0528 50.1309 10.7964C50.1309 10.5401 50.0377 10.3377 49.8645 10.1488C49.7047 9.95987 49.4917 9.87891 49.2386 9.87891Z"
-                  fill="#BDBDBD"
-                />{' '}
-                <path
-                  d="M54.2318 9.89258C53.9921 9.89258 53.779 9.98703 53.6192 10.1624C53.4461 10.3379 53.3662 10.5537 53.3662 10.8101C53.3662 11.0665 53.4461 11.2689 53.6192 11.4578C53.7924 11.6332 53.9921 11.7277 54.2318 11.7277C54.4715 11.7277 54.6846 11.6332 54.8577 11.4578C55.0308 11.2824 55.1241 11.0665 55.1241 10.8101C55.1241 10.5537 55.0308 10.3379 54.8577 10.1624C54.6846 9.97354 54.4715 9.89258 54.2318 9.89258Z"
-                  fill="#BDBDBD"
-                />{' '}
-                <path
-                  d="M56.4431 3.22656H39.5573C38.2655 3.22656 37.2002 4.30602 37.2002 5.61487V15.2895C37.2002 16.5984 38.2655 17.6778 39.5573 17.6778H46.1891C46.1891 17.6778 47.4675 21.2266 47.9336 21.2266C48.3997 21.2266 49.7847 17.6778 49.7847 17.6778H56.4431C57.7348 17.6778 58.8002 16.5984 58.8002 15.2895V5.61487C58.8002 4.30602 57.7348 3.22656 56.4431 3.22656ZM43.4725 12.1591C43.1395 12.5369 42.6202 12.6988 42.0609 12.6988C41.5548 12.6988 41.1819 12.5504 40.9156 12.3345H40.9023V12.6044H39.6372V7.00467H40.9023V9.1501H40.9289C41.2752 8.85325 41.7279 8.7588 42.2606 8.73181C42.7134 8.71832 43.1928 9.00167 43.4858 9.33901C43.7654 9.67634 43.9785 10.2026 43.9785 10.7828C43.9785 11.417 43.8187 11.7813 43.4725 12.1591ZM46.2024 12.6583H44.9107C44.9107 12.6583 44.9107 9.71682 44.9107 9.19058C44.9107 8.39448 44.2848 8.28653 44.2848 8.28653V6.89673C44.2848 6.89673 46.0959 7.00467 46.2024 9.23106C46.2024 9.86524 46.2024 12.6583 46.2024 12.6583ZM51.2762 11.5924C51.1696 11.8488 51.0098 12.0646 50.7967 12.267C50.597 12.4559 50.3573 12.6044 50.0909 12.7123C49.8246 12.8203 49.545 12.8742 49.252 12.8742C48.959 12.8742 48.6794 12.8203 48.4263 12.7123C48.16 12.6044 47.9203 12.4559 47.7205 12.267C47.5075 12.0646 47.3477 11.8353 47.2411 11.5924C47.1346 11.3495 47.0813 11.0796 47.0813 10.7963C47.0813 10.5129 47.1346 10.2565 47.2411 10.0002C47.3477 9.7573 47.5075 9.52791 47.7205 9.32551C47.9336 9.13661 48.16 8.98818 48.4263 8.88024C48.6927 8.77229 48.9723 8.71832 49.252 8.71832C49.545 8.71832 49.8246 8.77229 50.0909 8.88024C50.3573 8.98818 50.597 9.13661 50.7967 9.32551C51.0098 9.52791 51.1563 9.7438 51.2762 10.0002C51.3827 10.2565 51.436 10.5129 51.436 10.7963C51.436 11.0796 51.3827 11.336 51.2762 11.5924ZM56.3632 12.1456C56.3632 13.1306 56.1768 13.7243 55.7506 14.1426C55.2313 14.6419 54.4988 14.6688 53.8863 14.5879V13.5759C54.4056 13.6299 55.1114 13.279 55.1114 12.6044V12.348H55.0981C54.8051 12.7528 54.3923 12.9012 53.8197 12.9012C53.3003 12.9012 52.8475 12.7123 52.5413 12.348C52.235 11.9837 52.0885 11.4979 52.0885 10.8907C52.0885 10.2026 52.2616 9.66284 52.5945 9.25805C52.9408 8.85325 53.4202 8.66434 53.9795 8.66434C54.4722 8.66434 54.7918 8.78578 55.0981 9.06914H55.1114V8.7588H56.3765V12.1456H56.3632Z"
-                  fill="#BDBDBD"
-                />{' '}
-                <path
-                  d="M84.002 4.25C84.0129 4.25 90.8797 4.25053 92.5977 4.71582C93.5446 4.96807 94.2897 5.71721 94.542 6.67188C94.9999 8.39891 94.9961 12 94.9961 12C94.9961 12.0252 94.9944 15.6073 94.5381 17.3281C94.2858 18.2789 93.5407 19.0281 92.5938 19.2842C90.8781 19.7459 83.998 19.7461 83.998 19.7461C83.9875 19.7461 77.1166 19.7456 75.4023 19.2842C74.4554 19.0319 73.7103 18.2828 73.458 17.3281C73.0017 15.6073 73 12.0252 73 12C73 12 73.0002 8.39887 73.4619 6.66797C73.7142 5.71718 74.4593 4.96804 75.4062 4.71191C77.1218 4.25014 84.002 4.25 84.002 4.25ZM81.751 15.2715L87.502 12L81.751 8.72852V15.2715Z"
-                  fill="#BDBDBD"
-                />{' '}
-                <path
-                  d="M120 8.83398C118.288 8.83398 116.833 10.2889 116.833 12.0007C116.833 13.7124 118.288 15.1673 120 15.1673C121.711 15.1673 123.166 13.7124 123.166 12.0007C123.166 10.2889 121.711 8.83398 120 8.83398Z"
-                  fill="#BDBDBD"
-                />{' '}
-                <path
-                  d="M124.059 2.5H116.027C112.918 2.5 110.5 4.91818 110.5 7.94091V15.9727C110.5 19.0818 112.918 21.5 116.027 21.5H124.059C127.082 21.5 129.5 19.0818 129.5 15.9727V7.94091C129.5 4.91818 127.082 2.5 124.059 2.5ZM120 17.0091C117.236 17.0091 115.077 14.7636 115.077 12.0864C115.077 9.40909 117.236 7.07727 120 7.07727C122.764 7.07727 124.923 9.32273 124.923 12C124.923 14.6773 122.764 17.0091 120 17.0091ZM125.095 8.11364C124.491 8.11364 123.973 7.59545 123.973 6.99091C123.973 6.38636 124.491 5.86818 125.095 5.86818C125.7 5.86818 126.218 6.38636 126.218 6.99091C126.218 7.59545 125.7 8.11364 125.095 8.11364Z"
-                  fill="#BDBDBD"
-                />
-              </svg>
+
+            {/* Company info: 16px / 140% / -3% / #9D9D9D, width 640 */}
+            <div className="mt-[16px] w-[640px] font-[Pretendard] text-[16px] leading-[22.4px] font-[200] tracking-[-0.03em] text-[#9D9D9D]">
+              <p>
+                대표자 : 이한별 | 사업자 등록번호 : 540-86-00384 | 통신판매업
+                신고번호 : 2020-경기김포-3725호
+              </p>
+              <p>
+                주소 : 경기도 김포시 사우중로 87 201호 | 이메일 :
+                kdigital@nextrunners.co.kr | 전화 : 070-4099-8219
+              </p>
             </div>
           </div>
-        </div>
-
-        {/* 구분선 */}
-        <div className="my-10 h-px w-full bg-white/10" />
-
-        {/* 하단 회사 정보 */}
-        <div className="space-y-2 text-xs leading-relaxed text-neutral-400">
-          <p>
-            대표자 : 이한별 | 사업자 등록번호 : 540-86-00384 | 통신판매업
-            신고번호 : 2020-경기김포-3725호
-          </p>
-          <p>
-            주소 : 경기도 김포시 사우중로 87 201호 | 이메일 :
-            kdigital@nextrunners.co.kr | 전화 : 070-4099-8219
-          </p>
         </div>
       </div>
     </footer>

--- a/src/index.css
+++ b/src/index.css
@@ -1,1 +1,3 @@
+/* Tailwind v4 */
 @import 'tailwindcss';
+@import 'pretendard/dist/web/static/pretendard.css';


### PR DESCRIPTION
## 🚀 PR 요약

footer에 레이아웃과 컬러, 자간을 수정했습니다 (피그마와 거의 완벽하게 똑같이하려고 노력)

## ✏️ 변경 유형

- [ ] feat: 새로운 기능 추가
- [ ] fix: 버그 수정
- [ ] docs: 문서 수정
- [v] style: 코드 포맷팅 등 스타일 변경
- [ ] refact: 코드 리팩토링
- [ ] test: 테스트 코드 추가/수정
- [ ] chore: 기타 변경사항

## ✅ 체크리스트

- [v] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [v] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 상세 내용 (선택)

### 작업 사항

- index.css에 pretendard 추가
- footer.tsx 수정

### 스크린 샷

<img width="1919" height="1080" alt="image" src="https://github.com/user-attachments/assets/79fd7e97-6271-4da5-8d39-c46086940006" />


