### PR TITLE
refact/커뮤니티 상세페이지 회원

### DIFF
--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -11,12 +11,56 @@ type User = {
   email: string
 }
 
+type Comment = {
+  id: number
+  content: string
+  author: {
+    id: number
+    nickname: string
+    profile_img_url: string | null
+  }
+  created_at: string
+  updated_at: string
+  is_author?: boolean
+}
+
+/**
+ * 요청 헤더에서 Authorization 토큰 확인
+ */
+function isAuthenticated(request: Request): boolean {
+  const authHeader = request.headers.get('Authorization')
+  return authHeader?.startsWith('Bearer ') ?? false
+}
+
+/**
+ * 인메모리 댓글 저장소 (postId별로 관리)
+ */
+const commentsStore: Record<number, Comment[]> = {
+  1: [], // 빈 배열로 시작 (0개)
+}
+
+/**
+ * 게시글별 좋아요 개수
+ */
+const likesStore: Record<number, number> = {
+  1: 0, // 좋아요 0개로 시작
+}
+
+/**
+ * 게시글별 조회수
+ */
+const viewCountStore: Record<number, number> = {
+  1: 0, // 조회수 0으로 시작
+}
+
+// 댓글 ID 카운터
+let nextCommentId = 1
+
 export const handlers = [
   /* =========================
    * Auth / Test
    * ========================= */
 
-  // GET 요청 모킹
   http.get('/api/users', () => {
     const users: User[] = [
       { id: 1, name: '김철수', email: 'kim@example.com' },
@@ -25,7 +69,6 @@ export const handlers = [
     return HttpResponse.json(users)
   }),
 
-  // POST 로그인
   http.post('/api/login', async ({ request }) => {
     const body = (await request.json()) as Partial<LoginRequestBody>
     const email = body.email ?? ''
@@ -45,7 +88,6 @@ export const handlers = [
     )
   }),
 
-  // 에러 테스트
   http.get('/api/error', () => {
     return HttpResponse.json(
       { message: '서버 에러가 발생했습니다' },
@@ -60,14 +102,23 @@ export const handlers = [
   /**
    * 커뮤니티 게시글 상세
    * GET /api/v1/posts/{postId}
+   * - 로그인 불필요
+   * - 조회수는 증가시키지 않음 (목록에서 클릭할 때만 증가)
    */
   http.get(
     'https://api.ozcodingschool.site/api/v1/posts/:postId',
-    ({ params }) => {
+    ({ params, request }) => {
       const { postId } = params
+      const authenticated = isAuthenticated(request)
+      const pid = Number(postId)
+
+      // 동적으로 계산
+      const commentCount = commentsStore[pid]?.length || 0
+      const likeCount = likesStore[pid] || 0
+      const viewCount = viewCountStore[pid] || 0
 
       return HttpResponse.json({
-        id: Number(postId),
+        id: pid,
         title: '커뮤니티 게시글 제목입니다',
         content: '이것은 커뮤니티 게시글 상세 내용입니다.\n줄바꿈도 포함됩니다.',
         category: {
@@ -79,13 +130,13 @@ export const handlers = [
           nickname: '프론트엔드유저',
           profile_img_url: null,
         },
-        like_count: 12,
-        comment_count: 2,
-        view_count: 123,
+        like_count: likeCount,        // 0부터 시작
+        comment_count: commentCount,  // 0부터 시작
+        view_count: viewCount,        // 0부터 시작
         created_at: '2024-01-10T12:00:00Z',
         updated_at: '2024-01-10T12:00:00Z',
-        is_liked: false,
-        is_author: false,
+        is_liked: authenticated ? false : undefined,
+        is_author: authenticated ? false : undefined,
       })
     }
   ),
@@ -93,76 +144,31 @@ export const handlers = [
   /**
    * 커뮤니티 댓글 목록
    * GET /api/v1/posts/{postId}/comments
+   * - 로그인 불필요
    */
   http.get(
     'https://api.ozcodingschool.site/api/v1/posts/:postId/comments',
-    () => {
+    ({ request, params }) => {
+      const { postId } = params
+      const authenticated = isAuthenticated(request)
+      const pid = Number(postId)
+
+      // postId에 해당하는 댓글 가져오기
+      const postComments = commentsStore[pid] || []
+
+      // 로그인 상태에 따라 is_author 추가
+      const results = postComments.map((comment) => ({
+        ...comment,
+        is_author: authenticated ? false : undefined,
+      }))
+
+      console.log(`📝 댓글 조회: postId=${pid}, 총 ${results.length}개`)
+
       return HttpResponse.json({
-        count: 2,
+        count: results.length,
         next: null,
         previous: null,
-        results: [
-          {
-            id: 1,
-            content: '첫 번째 댓글입니다.',
-            author: {
-              id: 2,
-              nickname: '댓글유저1',
-              profile_img_url: null,
-            },
-            created_at: '2024-01-10T13:00:00Z',
-            updated_at: '2024-01-10T13:00:00Z',
-            is_author: false,
-          },
-          {
-            id: 2,
-            content: '두 번째 댓글입니다.',
-            author: {
-              id: 3,
-              nickname: '댓글유저2',
-              profile_img_url: null,
-            },
-            created_at: '2024-01-10T14:00:00Z',
-            updated_at: '2024-01-10T14:00:00Z',
-            is_author: false,
-          },
-          {
-            id: 3,
-            content: '세 번째 댓글입니다.',
-            author: {
-              id: 4,
-              nickname: '댓글유저3',
-              profile_img_url: null,
-            },
-            created_at: '2024-01-10T14:00:00Z',
-            updated_at: '2024-01-10T14:00:00Z',
-            is_author: false,
-          },
-          {
-            id: 4,
-            content: '네 번째 댓글입니다.',
-            author: {
-              id: 5,
-              nickname: '댓글유저4',
-              profile_img_url: null,
-            },
-            created_at: '2024-01-10T14:00:00Z',
-            updated_at: '2024-01-10T14:00:00Z',
-            is_author: false,
-          },
-          {
-            id: 5,
-            content: '다섯 번째 댓글입니다.',
-            author: {
-              id: 6,
-              nickname: '댓글유저5',
-              profile_img_url: null,
-            },
-            created_at: '2024-01-10T14:00:00Z',
-            updated_at: '2024-01-10T14:00:00Z',
-            is_author: false,
-          },
-        ],
+        results,
       })
     }
   ),
@@ -170,12 +176,179 @@ export const handlers = [
   /**
    * 커뮤니티 게시글 삭제
    * DELETE /api/v1/posts/{postId}
+   * - 로그인 필요
    */
   http.delete(
     'https://api.ozcodingschool.site/api/v1/posts/:postId',
-    () => {
+    ({ request }) => {
+      if (!isAuthenticated(request)) {
+        return HttpResponse.json(
+          { error_detail: '자격 인증 데이터가 제공되지 않았습니다.' },
+          { status: 401 }
+        )
+      }
+
       return HttpResponse.json({
         detail: '게시글이 삭제되었습니다.',
+      })
+    }
+  ),
+
+  /**
+   * 커뮤니티 댓글 작성
+   * POST /api/v1/posts/{postId}/comments
+   * - 로그인 필요
+   */
+  http.post(
+    'https://api.ozcodingschool.site/api/v1/posts/:postId/comments',
+    async ({ request, params }) => {
+      if (!isAuthenticated(request)) {
+        return HttpResponse.json(
+          { error_detail: '자격 인증 데이터가 제공되지 않았습니다.' },
+          { status: 401 }
+        )
+      }
+
+      const { postId } = params
+      const pid = Number(postId)
+      const body = (await request.json()) as { content: string }
+
+      // 새 댓글 생성
+      const newComment: Comment = {
+        id: nextCommentId++,
+        content: body.content,
+        author: {
+          id: 100,
+          nickname: '로그인유저',
+          profile_img_url: null,
+        },
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      }
+
+      // postId에 해당하는 댓글 배열이 없으면 생성
+      if (!commentsStore[pid]) {
+        commentsStore[pid] = []
+      }
+
+      // 댓글 추가
+      commentsStore[pid].push(newComment)
+
+      console.log(`✅ 댓글 등록 성공! postId: ${pid}, 총 댓글: ${commentsStore[pid].length}개`)
+
+      return HttpResponse.json(
+        { detail: '댓글이 등록되었습니다.' },
+        { status: 201 }
+      )
+    }
+  ),
+
+  /**
+   * 커뮤니티 댓글 수정
+   * PUT /api/v1/posts/{postId}/comments/{commentId}
+   * - 로그인 필요
+   */
+  http.put(
+    'https://api.ozcodingschool.site/api/v1/posts/:postId/comments/:commentId',
+    ({ request, params }) => {
+      if (!isAuthenticated(request)) {
+        return HttpResponse.json(
+          { error_detail: '자격 인증 데이터가 제공되지 않았습니다.' },
+          { status: 401 }
+        )
+      }
+
+      const { commentId } = params
+
+      return HttpResponse.json({
+        id: Number(commentId),
+        content: '수정된 댓글 내용',
+        updated_at: new Date().toISOString(),
+      })
+    }
+  ),
+
+  /**
+   * 커뮤니티 댓글 삭제
+   * DELETE /api/v1/posts/{postId}/comments/{commentId}
+   * - 로그인 필요
+   */
+  http.delete(
+    'https://api.ozcodingschool.site/api/v1/posts/:postId/comments/:commentId',
+    ({ request }) => {
+      if (!isAuthenticated(request)) {
+        return HttpResponse.json(
+          { error_detail: '자격 인증 데이터가 제공되지 않았습니다.' },
+          { status: 401 }
+        )
+      }
+
+      return HttpResponse.json({
+        detail: '댓글이 삭제되었습니다.',
+      })
+    }
+  ),
+
+  /**
+   * 커뮤니티 게시글 좋아요
+   * POST /api/v1/posts/{postId}/like
+   * - 로그인 필요
+   */
+  http.post(
+    'https://api.ozcodingschool.site/api/v1/posts/:postId/like',
+    ({ request, params }) => {
+      if (!isAuthenticated(request)) {
+        return HttpResponse.json(
+          { error_detail: '자격 인증 데이터가 제공되지 않았습니다.' },
+          { status: 401 }
+        )
+      }
+
+      const { postId } = params
+      const pid = Number(postId)
+
+      // 좋아요 증가
+      if (!likesStore[pid]) {
+        likesStore[pid] = 0
+      }
+      likesStore[pid]++
+
+      console.log(`👍 좋아요 추가! postId: ${pid}, 총 좋아요: ${likesStore[pid]}개`)
+
+      return HttpResponse.json(
+        { detail: '좋아요가 등록되었습니다.' },
+        { status: 201 }
+      )
+    }
+  ),
+
+  /**
+   * 커뮤니티 게시글 좋아요 취소
+   * DELETE /api/v1/posts/{postId}/like
+   * - 로그인 필요
+   */
+  http.delete(
+    'https://api.ozcodingschool.site/api/v1/posts/:postId/like',
+    ({ request, params }) => {
+      if (!isAuthenticated(request)) {
+        return HttpResponse.json(
+          { error_detail: '자격 인증 데이터가 제공되지 않았습니다.' },
+          { status: 401 }
+        )
+      }
+
+      const { postId } = params
+      const pid = Number(postId)
+
+      // 좋아요 감소
+      if (likesStore[pid] && likesStore[pid] > 0) {
+        likesStore[pid]--
+      }
+
+      console.log(`👎 좋아요 취소! postId: ${pid}, 총 좋아요: ${likesStore[pid]}개`)
+
+      return HttpResponse.json({
+        detail: '좋아요가 취소되었습니다.',
       })
     }
   ),


### PR DESCRIPTION
## 🚀 PR 요약

>커뮤니티 상세페이지 회원 UI 제작 완료 

## ✏️ 변경 유형

- [ ] feat: 새로운 기능 추가
- [ ] fix: 버그 수정
- [ ] docs: 문서 수정
- [ ] style: 코드 포맷팅 등 스타일 변경
- [x] refact: 코드 리팩토링
- [ ] test: 테스트 코드 추가/수정
- [ ] chore: 기타 변경사항

## ✅ 체크리스트

- [x] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [ ] 커밋에 관련된 이슈 번호를 포함했습니다.
- [ ] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 상세 내용 (선택)

### 작업 사항

-  API명세서를 활횽해 예시 API 갖고왔습니다
- 쿠키에 담겨있는 refrashToken로 로그인 하는 로직을 구현했습니다
- 로그인 사용자만 좋아요 가능하도록 접근 제어하도록 수정하였습니다
- 로그인을 안했다면 로그인 페이지완 연결하면 갈수 있도록 코드를 수정하였습니다
- 좋아요 / 좋아요 취소 토글 처리하였습니다
- 좋아요 상태(isLiked)와 좋아요 수(likeCount)를 React state로 관리하고,
좋아요 / 취소 API 호출 성공 시 해당 state를 직접 업데이트하여 즉시 UI에 반영되도록 구현했습니다.

- 작성 회원 UI 제작 예정입니다
- 수정, 삭제 제작 예정입니다
- 무한스크롤 구현예정입니다
- 카테고리에에 있는 글을 들어갈때마다 상세페이지의 카테고리가 변하도록 수정할것 입니다
- 가독성과 유지보수성을 높이기 위해 CommunityDetailPage의 로직을 역할별로 분리하고 파일 단위로 구조를 개선 할 예정입니다

### 스크린 샷

**수정전 정적 UI**

<img width="1497" height="861" alt="스크린샷 2026-01-22 오후 5 07 01" src="https://github.com/user-attachments/assets/75baf67e-49b5-4583-99b1-cedbe08b3e7b" />

**비회원 상세페이지 UI**

<img width="1512" height="899" alt="스크린샷 2026-01-22 오후 9 10 30" src="https://github.com/user-attachments/assets/9cff722c-949b-46f1-acc3-9fa0bc48230c" />

**동적 회원 상세페이지**

<img width="1512" height="862" alt="스크린샷 2026-01-22 오후 9 10 42" src="https://github.com/user-attachments/assets/3e60e0ee-39b2-4295-bd5e-a4a6887fa4ae" />




