### PR TITLE
Refact/게시글 등록하기 오류 수정 

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import CommunityDetailPage from './pages/community/CommunityDetailPage'
 import CommunityListPage from './pages/community/CommunityListPage'
 import CommunityCreatePage from './pages/community/CommunityCreatePage'
 import CommunityEditPage from './pages/community/CommunityEditPage'
+import NotFoundPage from './pages/NotFoundPage'
 
 export default function App() {
   return (
@@ -23,6 +24,9 @@ export default function App() {
             element={<CommunityEditPage />}
           />
           <Route path="/community/:postId" element={<CommunityDetailPage />} />
+          
+          {/* ✅ 404 Not Found */}
+          <Route path="*" element={<NotFoundPage />} />
         </Routes>
       </main>
 

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -82,7 +82,7 @@ export async function createCommunityPost(
   token?: string
 ): Promise<CreateCommunityPostResponse> {
   const res = await api.post<CreateCommunityPostResponse>(
-    '/api/v1/posts/',
+    '/api/v1/posts',
     body,
     { headers: { ...withAuth(token) } }
   )

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -82,7 +82,7 @@ export async function createCommunityPost(
   token?: string
 ): Promise<CreateCommunityPostResponse> {
   const res = await api.post<CreateCommunityPostResponse>(
-    '/api/v1/posts',
+    '/api/v1/posts/',
     body,
     { headers: { ...withAuth(token) } }
   )

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -268,6 +268,49 @@ export const handlers = [
   }),
 
   /**
+   * 2-1) 게시글 작성
+   * POST /api/v1/posts
+   * - 로그인 필요
+   */
+  http.post('*/api/v1/posts', async ({ request }) => {
+    /* 임시 테스트를 위해 주석 처리 (로그인 없이도 가능)
+    if (!isAuthenticated(request)) {
+      return HttpResponse.json(
+        { error_detail: '자격 인증 데이터가 제공되지 않았습니다.' },
+        { status: 401 }
+      )
+    }
+    */
+
+    const body = (await request.json()) as {
+      title: string
+      content: string
+      category_id: number
+    }
+
+    const newPost: CommunityPostListItem = {
+      id: postsStore.length + 1,
+      title: body.title,
+      content_preview: body.content.substring(0, 100),
+      author: { id: 100, nickname: '로그인유저', profile_img_url: null },
+      created_at: nowISO(),
+      updated_at: nowISO(),
+      category_id: body.category_id,
+      thumbnail_img_url: null,
+      like_count: 0,
+      comment_count: 0,
+      view_count: 0,
+    }
+
+    postsStore.unshift(newPost) // 최신글이 위로 오도록 앞에 추가
+
+    return HttpResponse.json(
+      { detail: '게시글이 등록되었습니다.', pk: newPost.id },
+      { status: 201 }
+    )
+  }),
+
+  /**
    * 3) 게시글 상세
    * GET /api/v1/posts/{postId}
    * - 로그인 불필요

--- a/src/pages/NotFoundPage.tsx
+++ b/src/pages/NotFoundPage.tsx
@@ -1,0 +1,16 @@
+import { Link } from 'react-router-dom'
+
+export default function NotFoundPage() {
+  return (
+    <div className="flex h-[calc(100vh-216px)] w-full flex-col items-center justify-center gap-6">
+      <h1 className="text-6xl font-bold text-[#7C3AED]">404</h1>
+      <p className="text-xl text-gray-600">요청하신 페이지를 찾을 수 없습니다.</p>
+      <Link
+        to="/community"
+        className="rounded-full bg-[#7C3AED] px-8 py-3 text-lg font-bold text-white transition-colors hover:bg-[#6D28D9]"
+      >
+        커뮤니티로 돌아가기
+      </Link>
+    </div>
+  )
+}

--- a/src/pages/community/CommunityCreatePage.tsx
+++ b/src/pages/community/CommunityCreatePage.tsx
@@ -387,7 +387,7 @@ export default function CommunityCreatePage() {
       }, token || undefined)
       
       alert('게시글이 등록되었습니다.')
-      navigate(`/community/detail/${data.pk}`)
+      navigate(`/community/${data.pk}`)
     } catch (error) {
       console.error('게시글 등록 실패:', error)
       alert('게시글 등록에 실패했습니다.')

--- a/src/pages/community/CommunityCreatePage.tsx
+++ b/src/pages/community/CommunityCreatePage.tsx
@@ -4,8 +4,7 @@ import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import rehypeRaw from 'rehype-raw'
 import {
-  ChevronDown, // Used in dropdowns? Check usage. actually List Group doesn't use it anymore, but keep if needed elsewhere.
-  // Original List, ListOrdered, Align... removed as they are replaced.
+  ChevronDown, 
 } from 'lucide-react'
 import {
   UndoIcon,
@@ -55,9 +54,7 @@ function replaceInfo(
   const original = textarea.value
   const newValue = original.substring(0, start) + text + original.substring(end)
   
-  // Set value (React controlled input needs state update, but we do this via returned value)
-  
-  // Return info to update state
+
   return {
     value: newValue,
     newSelectionStart: cursorInfo?.newStart ?? start + text.length,
@@ -65,9 +62,6 @@ function replaceInfo(
   }
 }
 
-// ----------------------------------------------------------------------
-// Component
-// ----------------------------------------------------------------------
 
 export default function CommunityCreatePage() {
   const navigate = useNavigate()
@@ -91,12 +85,11 @@ export default function CommunityCreatePage() {
   const fontSizeRef = useRef<HTMLDivElement>(null)
   const textColorRef = useRef<HTMLDivElement>(null)
   
-  // --- History for Undo/Redo ---
-  // historyStack[historyIndex] = currentContent
+
   const [historyStack, setHistoryStack] = useState<string[]>([''])
   const [historyIndex, setHistoryIndex] = useState(0)
 
-  // --- Initial Data Fetch ---
+
   useEffect(() => {
     async function fetchCategories() {
       try {
@@ -109,7 +102,7 @@ export default function CommunityCreatePage() {
     fetchCategories()
   }, [])
 
-  // --- Click Outside Handler for Dropdowns ---
+
   useEffect(() => {
     function handleClickOutside(event: MouseEvent) {
       if (fontSizeRef.current && !fontSizeRef.current.contains(event.target as Node)) {
@@ -132,7 +125,7 @@ export default function CommunityCreatePage() {
     }
   }, [])
 
-  // --- History Management Methods ---
+
   const pushToHistory = useCallback((newContent: string) => {
     if (newContent === historyStack[historyIndex]) return // No change
 

--- a/src/pages/community/CommunityCreatePage.tsx
+++ b/src/pages/community/CommunityCreatePage.tsx
@@ -31,7 +31,7 @@ import {
   ToolbarIndentIcon
 } from '../../components/icons/CustomIcons'
 
-import { api } from '../../api/api'
+import { api, createCommunityPost, getAccessToken } from '../../api/api'
 import type { CommunityCategory, CreateCommunityPostResponse } from '../../types'
 
 // ----------------------------------------------------------------------
@@ -386,20 +386,18 @@ export default function CommunityCreatePage() {
 
     try {
       setIsLoading(true)
-      const res = await api.post<CreateCommunityPostResponse>('/api/v1/posts', {
+      const token = getAccessToken()
+      const data = await createCommunityPost({
         category_id: categoryId,
         title,
         content,
-      })
+      }, token || undefined)
+      
       alert('게시글이 등록되었습니다.')
-      if (res.data && res.data.pk) {
-        navigate(`/community/${res.data.pk}`)
-      } else {
-        navigate('/community')
-      }
+      navigate(`/community/detail/${data.pk}`)
     } catch (error) {
       console.error('게시글 등록 실패:', error)
-      alert('게시글 등록 중 오류가 발생했습니다.')
+      alert('게시글 등록에 실패했습니다.')
     } finally {
       setIsLoading(false)
     }


### PR DESCRIPTION
## 🚀 PR 요약

게시글 등록이 실패하던 오류를 고쳤습니다..

## ✏️ 변경 유형

- [v] feat: 새로운 기능 추가
- [ ] fix: 버그 수정
- [ ] docs: 문서 수정
- [ ] style: 코드 포맷팅 등 스타일 변경
- [v] refact: 코드 리팩토링
- [ ] test: 테스트 코드 추가/수정
- [ ] chore: 기타 변경사항

## ✅ 체크리스트

- [v] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [v] 커밋에 관련된 이슈 번호를 포함했습니다.
- [v] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 상세 내용 (선택)

### 작업 사항

- 404 페이지 추가: 잘못된 경로로 접근했을 때를 대비해 NotFoundPage 컴포넌트를 만들고, App.tsx에 catch-all 라우트(*)를 추가했습니다
- 라우트 통일 및 수정 
- MSW 핸들러가 인증 토큰 요구하던걸 임시 주석처리.
- 게시글 등록 핸들러 추가

### 참고 사항

- 게시글 삭제는 재윤이가 이제 진행 예정 
- 게시글 수정은 다음 작업

### 스크린 샷

> <img width="1891" height="876" alt="image" src="https://github.com/user-attachments/assets/2609ae97-42d4-4297-8774-a23eb67cd7b7" />

## 🔗 연관된 이슈

> closes #51 
