### PR TITLE
refact/작성자 UI 로직 수정

### DIFF
--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -61,11 +61,17 @@ type Comment = {
 }
 
 /**
- * Authorization 토큰 유무만 체크 (지금 단계에선 “로그인 되어있다/아니다”만 필요)
+ * Authorization 토큰 유무 또는 쿠키 유무 체크
  */
 function isAuthenticated(request: Request): boolean {
   const authHeader = request.headers.get('Authorization')
-  return authHeader?.startsWith('Bearer ') ?? false
+  const hasToken = authHeader?.startsWith('Bearer ') ?? false
+  
+  // 쿠키 방식 체크 (refreshToken 또는 accessToken)
+  const cookie = request.headers.get('Cookie') || ''
+  const hasCookie = cookie.includes('refreshToken') || cookie.includes('accessToken')
+  
+  return hasToken || hasCookie
 }
 
 /** =========================
@@ -380,8 +386,8 @@ export const handlers = [
       view_count: viewCount,
       created_at: post.created_at,
       updated_at: post.updated_at,
-      is_liked: authenticated ? false : undefined,
-      is_author: authenticated ? post.author.id === 1 : undefined,
+      is_liked: authenticated ? false : undefined, // 연동 전엔 false
+      is_author: authenticated ? (post.author.id === 1) : false,
     }
 
     return HttpResponse.json(detail)

--- a/src/pages/community/CommunityDetailPage.tsx
+++ b/src/pages/community/CommunityDetailPage.tsx
@@ -76,8 +76,8 @@ export default function CommunityDetailPage() {
   const loggedIn = isLoggedIn()
   const [currentUserId, setCurrentUserId] = useState<number | null>(null)
 
-  // 현재 로그인한 사용자가 게시글 작성자인지 확인
-  const isAuthor = post && currentUserId !== null && post.author.id === currentUserId
+  // 현재 로그인한 사용자가 게시글 작성자인지 확인 (서버 응답 우선, 로컬 검증 차선)
+  const isAuthor = post?.is_author || (post && currentUserId !== null && post.author.id === currentUserId)
 
   // 무한 스크롤
   const [page, setPage] = useState(1)


### PR DESCRIPTION
## 🚀 PR 요약

게시글 작성시 작성자 UI가 보이지 않는 오류 

## ✏️ 변경 유형

- [ ] feat: 새로운 기능 추가
- [ ] fix: 버그 수정
- [ ] docs: 문서 수정
- [ ] style: 코드 포맷팅 등 스타일 변경
- [V] refact: 코드 리팩토링
- [ ] test: 테스트 코드 추가/수정
- [ ] chore: 기타 변경사항

## ✅ 체크리스트

- [V] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [ ] 커밋에 관련된 이슈 번호를 포함했습니다.
- [ ] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 상세 내용 (선택)

### 작업 사항
쿠키 방식 인증 지원 (handlers.ts):
가짜 서버(Mock API)가 이제 Authorization 헤더뿐만 아니라 브라우저의 쿠키(refreshToken, accessToken)를 통해서도 로그인 상태를 인식할 수 있도록 업데이트했습니다.
작성자 판단 로직 개선 (CommunityDetailPage.tsx): 
기존에는 작성자 확인을 위해 브라우저의 localStorage 정보에만 의존했으나, 이제는 서버(API)에서 내려주는 is_author 값을 우선적으로 사용하도록 수정했습니다.
