### PR TITLE
Feat/ 리스트 페이지 로딩 애니메이션 추가 

### DIFF
--- a/src/pages/community/CommunityDetailPage.tsx
+++ b/src/pages/community/CommunityDetailPage.tsx
@@ -208,11 +208,15 @@ export default function CommunityDetailPage() {
         setLoading(true)
         setError(null)
 
-        const postData = await getCommunityPostDetail(Number(postId))
-        const commentData = await getCommunityComments(Number(postId), {
-          page: 1,
-          page_size: COMMENTS_PER_PAGE
-        })
+        // 최소 200ms 로딩 시간 보장
+        const [postData, commentData] = await Promise.all([
+          getCommunityPostDetail(Number(postId)),
+          getCommunityComments(Number(postId), {
+            page: 1,
+            page_size: COMMENTS_PER_PAGE
+          }),
+          new Promise(resolve => setTimeout(resolve, 200))
+        ])
 
         setPost(postData)
         setComments(commentData.results || [])


### PR DESCRIPTION
## 🚀 PR 요약

리스트 페이지에 로딩 애니메이션 추가 (초기 로딩 0.2초 + 스크롤 시에도 추가)
상세 페이지 로딩 애니메이션 초기로딩 0.2초로 통일
## ✏️ 변경 유형

- [v] feat: 새로운 기능 추가
- [ ] fix: 버그 수정
- [ ] docs: 문서 수정
- [ ] style: 코드 포맷팅 등 스타일 변경
- [v] refact: 코드 리팩토링
- [ ] test: 테스트 코드 추가/수정
- [ ] chore: 기타 변경사항

## ✅ 체크리스트

- [v] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [v] 커밋에 관련된 이슈 번호를 포함했습니다.
- [v] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 상세 내용 (선택)

### 작업 사항
리스트 페이지 로딩 애니메이션 추가 
상세 페이지 로딩 애니메이션 초기 로딩 시간 0.2초 통일 ( 기존은 너무 짧았음 )


### 스크린 샷

> 0.2초는 너무 짧아서 찍지못함 issue

## 🔗 연관된 이슈

> closes #71 
> closes #76 
