### PR TITLE
Feat/presigned URL 방식으로 이미지 요청 방식 변경

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -190,6 +190,44 @@ export async function unlikeCommunityPost(postId: number) {
   return res.data
 }
 
+// =============================
+// Image Upload API (Presigned URL)
+// =============================
+
+export interface PresignedUrlResponse {
+  presigned_url: string
+  img_url: string
+  key: string
+}
+
+/**
+ * S3 이미지 업로드를 위한 Presigned URL 발급 요청
+ * @param fileName - 업로드할 파일명 (예: "example.png")
+ * @returns presigned_url, img_url, key
+ */
+export async function getPresignedUrl(fileName: string): Promise<PresignedUrlResponse> {
+  const token = getAccessToken()
+  const res = await api.put<PresignedUrlResponse>(
+    '/api/v1/questions/presigned-url',
+    { file_name: fileName },
+    { headers: { ...withAuth(token || undefined) } }
+  )
+  return res.data
+}
+
+/**
+ * Presigned URL을 사용하여 S3에 파일 업로드
+ * @param presignedUrl - 백엔드에서 발급받은 Presigned URL
+ * @param file - 업로드할 파일
+ */
+export async function uploadToS3(presignedUrl: string, file: File): Promise<void> {
+  await axios.put(presignedUrl, file, {
+    headers: {
+      'Content-Type': file.type,
+    },
+  })
+}
+
 export const communityApi = {
   getCategories: getCommunityCategories,
   getPosts: getCommunityPosts,


### PR DESCRIPTION
## 🚀 PR 요약

서버에 이미지가 저장되지 않는 방식을 
바꾸었습니다

## ✏️ 변경 유형

- [V] feat: 새로운 기능 추가
- [ ] fix: 버그 수정
- [ ] docs: 문서 수정
- [ ] style: 코드 포맷팅 등 스타일 변경
- [V] refact: 코드 리팩토링
- [ ] test: 테스트 코드 추가/수정
- [ ] chore: 기타 변경사항

## ✅ 체크리스트

- [V] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [V] 커밋에 관련된 이슈 번호를 포함했습니다.
- [V] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 상세 내용 (선택)

### 작업 사항

-API 함수 추가 (src/api/api.ts)
-백엔드에 Presigned URL을 요청하는 getPresignedUrl 함수 추가
-받은 URL로 S3에 직접 업로드하는 uploadToS3 함수 추가

-글 작성 페이지 수정 (src/pages/community/CommunityCreatePage.tsx)
-기존 로컬 미리보기 방식 → Presigned URL 업로드 방식으로 로직 전면 수정
-업로드 중일 때 버튼 비활성화 및 "업로드중..." 표시 추가
-불필요한 코드(objectUrlsRef) 제거

### 참고 사항

- 현재 404 오류 뜨는 이유 => 백엔드 API 구현이 안되어있음 

### 스크린 샷

> <img width="1917" height="865" alt="image" src="https://github.com/user-attachments/assets/f2ec7653-3760-466a-bdee-55e19db8b606" />

## 🔗 연관된 이슈

> closes #80 
