### PR TITLE
fix: 카테고리 목록 조회 api 수정

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -21,7 +21,7 @@ export const api = axios.create({
   },
 })
 
-/** (옵션) JS로 읽을 수 있는 쿠키일 때만 사용 가능 */
+/** JS로 읽을 수 있는 쿠키일 때만 사용 가능 */
 function getCookie(name: string): string | null {
   const value = `; ${document.cookie}`
   const parts = value.split(`; ${name}=`)
@@ -59,7 +59,7 @@ export function toQuery(params?: Record<string, unknown>) {
   return sp
 }
 
-/** Authorization 헤더 주입 (토큰을 JS에서 읽을 수 있을 때만 의미 있음) */
+/** Authorization 헤더 주입 */
 function withAuth(token?: string) {
   if (!token) return {}
   return { Authorization: `Bearer ${token}` }
@@ -202,7 +202,7 @@ export interface PresignedUrlResponse {
 
 /**
  * S3 이미지 업로드를 위한 Presigned URL 발급 요청
- * @param fileName - 업로드할 파일명 (예: "example.png")
+ * @param fileName - 업로드할 파일명 
  * @returns presigned_url, img_url, key
  */
 export async function getPresignedUrl(fileName: string): Promise<PresignedUrlResponse> {

--- a/src/pages/community/CommunityListPage.tsx
+++ b/src/pages/community/CommunityListPage.tsx
@@ -89,7 +89,7 @@ function ChevronRightIcon() {
 
 const ALL_CATEGORY_ID = 0 as const
 
-// 정렬 옵션(피그마 기준)
+// 정렬 옵션
 type SortKey = 'views' | 'likes' | 'comments' | 'latest' | 'oldest'
 
 const SORT_LABEL: Record<SortKey, string> = {
@@ -100,7 +100,7 @@ const SORT_LABEL: Record<SortKey, string> = {
   oldest: '오래된 순',
 }
 
-// 서버 파라미터 매핑(백/MSW에 맞춰 필요하면 값만 바꿔)
+// 서버 파라미터 매핑
 const SORT_PARAM: Record<SortKey, string> = {
   views: 'views',
   likes: 'likes',
@@ -111,7 +111,7 @@ const SORT_PARAM: Record<SortKey, string> = {
 
 export default function CommunityListPage() {
   const navigate = useNavigate()
-  const [selectedCategoryId, setSelectedCategoryId] = useState<number>(6)
+  const [selectedCategoryId, setSelectedCategoryId] = useState<number>(ALL_CATEGORY_ID)
   
   // 무한 스크롤 상태
   const [posts, setPosts] = useState<CommunityPostListItem[]>([])
@@ -215,8 +215,6 @@ export default function CommunityListPage() {
 
   const onSubmitSearch = () => {
     // keyword 상태가 변경되었을 때 useEffect가 트리거되도록 처리
-    // 이미 useEffect[keyword]가 있으므로 setKeyword('') -> setKeyword(val) 식이면 되지만
-    // 여기서는 단순히 trigger를 위해 keyword 상태만 확인
   }
   
   const onClickWrite = () => navigate('/community/new')


### PR DESCRIPTION
## 🚀 PR 요약

 CommunityCreatePage.tsx와 api.ts의 카테고리 조회 로직이 API 명세와 일치함을 확인했습니다.

## ✏️ 변경 유형

- [ ] feat: 새로운 기능 추가
- [V] fix: 버그 수정
- [ ] docs: 문서 수정
- [ ] style: 코드 포맷팅 등 스타일 변경
- [ ] refact: 코드 리팩토링
- [ ] test: 테스트 코드 추가/수정
- [ ] chore: 기타 변경사항

## ✅ 체크리스트

- [] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [ ] 커밋에 관련된 이슈 번호를 포함했습니다.
- [V] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 상세 내용 (선택)

### 작업 사항

CommunityListPage.tsx에서 초기 카테고리 선택값을 6에서
 ALL_CATEGORY_ID (0, 전체)로 변경했습니다. 
이제 페이지 진입 시 모든 게시글을 불러오게 됩니다

### 참고 사항

- 게시글 목록 조회 API 연결은 다음 작업.




