### PR TITLE
feat: 게시글 조회 API 반영

### DIFF
--- a/src/components/community/list/CommunitySearchBar.tsx
+++ b/src/components/community/list/CommunitySearchBar.tsx
@@ -84,7 +84,7 @@ type Props = {
 const FILTER_ITEMS: Array<{ key: SearchFilterOption; label: string }> = [
   { key: 'title', label: '제목' },
   { key: 'content', label: '내용' },
-  { key: 'author', label: '작성자' },
+  { key: 'nickname', label: '작성자' },
 ]
 
 export default function CommunitySearchBar({
@@ -100,7 +100,7 @@ export default function CommunitySearchBar({
 
   // ✅ 기존 기본값이 title_or_content로 들어오면, 피그마 기준으로 '제목'으로 맞춤
   useEffect(() => {
-    if (filter === 'title_or_content') onChangeFilter('title')
+    if (filter === 'all') onChangeFilter('title')
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 

--- a/src/pages/community/CommunityListPage.tsx
+++ b/src/pages/community/CommunityListPage.tsx
@@ -90,10 +90,9 @@ function ChevronRightIcon() {
 const ALL_CATEGORY_ID = 0 as const
 
 // 정렬 옵션
-type SortKey = 'views' | 'likes' | 'comments' | 'latest' | 'oldest'
+type SortKey = 'likes' | 'comments' | 'latest' | 'oldest'
 
 const SORT_LABEL: Record<SortKey, string> = {
-  views: '조회순',
   likes: '좋아요 순',
   comments: '댓글 순',
   latest: '최신순',
@@ -102,7 +101,6 @@ const SORT_LABEL: Record<SortKey, string> = {
 
 // 서버 파라미터 매핑
 const SORT_PARAM: Record<SortKey, string> = {
-  views: 'views',
   likes: 'likes',
   comments: 'comments',
   latest: 'latest',
@@ -120,7 +118,7 @@ export default function CommunityListPage() {
   const [isLoading, setIsLoading] = useState(false)
   const [isInitialLoading, setIsInitialLoading] = useState(true)
   
-  const [filter, setFilter] = useState<SearchFilterOption>('title_or_content')
+  const [filter, setFilter] = useState<SearchFilterOption>('all')
   const [keyword, setKeyword] = useState('')
 
   // 정렬

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,17 +1,14 @@
-// 명세서: search_filter enum = "author" | "title" | "content" | "title_or_content"
 export type SearchFilterOption =
-  | 'author'
+  | 'all'
   | 'title'
   | 'content'
-  | 'title_or_content'
+  | 'nickname'
 
-// 명세서: sort enum = "latest" | "oldest" | "most_views" | "most_likes" | "most_comments"
 export type SortOption =
   | 'latest'
+  | 'likes'
+  | 'comments'
   | 'oldest'
-  | 'most_views'
-  | 'most_likes'
-  | 'most_comments'
 
 // =======================
 // Community - Types


### PR DESCRIPTION
## 🚀 PR 요약

게시글 조회 API 스웨거 화면에 있는 정렬 기준, 필터 수정 , 타입정의를 업데이트 했습니다

## ✏️ 변경 유형

- [V] feat: 새로운 기능 추가
- [ ] fix: 버그 수정
- [ ] docs: 문서 수정
- [ ] style: 코드 포맷팅 등 스타일 변경
- [V] refact: 코드 리팩토링
- [ ] test: 테스트 코드 추가/수정
- [ ] chore: 기타 변경사항

## ✅ 체크리스트

- [V] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [V] 커밋에 관련된 이슈 번호를 포함했습니다.
- [V] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 상세 내용 (선택)

### 작업 사항

정렬 옵션 수정: API 명세에 맞춰 '조회순(views)'을 제거하고 latest, likes, comments, oldest로 정리했습니다.
검색 필터 수정: author를 nickname으로 변경하고, 전체 검색 옵션(all)도 명확히 반영했습니다.
타입 정의 업데이트: src/types/index.ts의 SearchFilterOption과 SortOption을 API 명세와 일치시켰습니다.

### 참고 사항

- 게시글 생성은 그 다음 작업 

## 🔗 연관된 이슈

> closes #89 
