### PR TITLE
fix:글쓰기 페이지 접근 불가 (비회원)

### DIFF
--- a/src/components/community/list/CommunitySearchBar.tsx
+++ b/src/components/community/list/CommunitySearchBar.tsx
@@ -1,6 +1,7 @@
-// src/components/community/list/CommunitySearchBar.tsx
+
 import { useEffect, useRef, useState } from 'react'
 import type { SearchFilterOption } from '../../../types'
+import { isLoggedIn } from '../../../api/api'
 
 function WritePencilIcon() {
   return (
@@ -80,7 +81,6 @@ type Props = {
   onClickWrite: () => void
 }
 
-// ✅ 피그마 드롭다운은 3개만(제목/내용/작성자)
 const FILTER_ITEMS: Array<{ key: SearchFilterOption; label: string }> = [
   { key: 'title', label: '제목' },
   { key: 'content', label: '내용' },
@@ -98,13 +98,11 @@ export default function CommunitySearchBar({
   const [open, setOpen] = useState(false)
   const wrapRef = useRef<HTMLDivElement | null>(null)
 
-  // ✅ 기존 기본값이 title_or_content로 들어오면, 피그마 기준으로 '제목'으로 맞춤
   useEffect(() => {
     if (filter === 'all') onChangeFilter('title')
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  // ✅ 바깥 클릭 시 닫기
   useEffect(() => {
     function onDocDown(e: MouseEvent) {
       if (!open) return
@@ -204,15 +202,17 @@ export default function CommunitySearchBar({
         </div>
       </div>
 
-      {/* 오른쪽: 글쓰기 */}
-      <button
-        type="button"
-        onClick={onClickWrite}
-        className="flex h-[40px] items-center justify-center gap-2 rounded-[6px] bg-[#6D28D9] px-[22px] text-[14px] font-semibold text-white hover:bg-[#5B21B6]"
-      >
-        <WritePencilIcon />
-        글쓰기
-      </button>
+      {/* 오른쪽: 글쓰기 - 로그인한 사용자에게만 표시 */}
+      {isLoggedIn() && (
+        <button
+          type="button"
+          onClick={onClickWrite}
+          className="flex h-[40px] items-center justify-center gap-2 rounded-[6px] bg-[#6D28D9] px-[22px] text-[14px] font-semibold text-white hover:bg-[#5B21B6]"
+        >
+          <WritePencilIcon />
+          글쓰기
+        </button>
+      )}
     </div>
   )
 }

--- a/src/pages/community/CommunityCreatePage.tsx
+++ b/src/pages/community/CommunityCreatePage.tsx
@@ -29,7 +29,9 @@ import {
   ToolbarIndentIcon
 } from '../../components/icons/CustomIcons'
 
-import { api, createCommunityPost, getAccessToken, getPresignedUrl, uploadToS3 } from '../../api/api'
+import { api, createCommunityPost, getAccessToken, getPresignedUrl, uploadToS3, isLoggedIn } from '../../api/api'
+
+
 import type { CommunityCategory } from '../../types'
 
 function getSelectionInfo(textarea: HTMLTextAreaElement) {
@@ -61,6 +63,14 @@ function replaceInfo(
 
 export default function CommunityCreatePage() {
   const navigate = useNavigate()
+
+  // 로그인 체크
+  useEffect(() => {
+    if (!isLoggedIn()) {
+      alert('로그인이 필요한 서비스입니다.')
+      navigate('/login', { replace: true, state: { from: '/community/new' } })
+    }
+  }, [navigate])
   
   // --- Data ---
   const [categories, setCategories] = useState<CommunityCategory[]>([])


### PR DESCRIPTION
## 🚀 PR 요약

회원일떄만 글쓰기 버튼이 보일 수 있도록 수정했습니다.

## ✏️ 변경 유형

- [ ] feat: 새로운 기능 추가
- [v] fix: 버그 수정
- [ ] docs: 문서 수정
- [ ] style: 코드 포맷팅 등 스타일 변경
- [v] refact: 코드 리팩토링
- [ ] test: 테스트 코드 추가/수정
- [ ] chore: 기타 변경사항

## ✅ 체크리스트

- [v] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [v] 커밋에 관련된 이슈 번호를 포함했습니다.
- [v] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 상세 내용 (선택)

### 작업 사항


커뮤니티 목록 페이지: 검색바(CommunitySearchBar.tsx) 오른쪽의 "글쓰기" 버튼을 비회원에게는 보이지 않도록 변경

글쓰기 페이지: 만약 URL로 직접 접근하더라도, 비회원일 경우 경고창을 띄우고 로그인 페이지로 이동하도록 안전장치를 추가

### 참고 사항

- 글쓰기 버튼이 보이고 싶다면 콘솔에
-  localStorage.removeItem('user') (로그아웃)
-  localStorage.setItem('user', 'test-user') (로그인)
엔터 시 글쓰기 버튼이 보이고 안보이고 가능.

(현재 실제 로그인 UI페이지가 없기 떄문에 임시로)

### 스크린 샷

<img width="1746" height="948" alt="image" src="https://github.com/user-attachments/assets/cdb2b203-4670-42ad-aa14-c3a8f12791a4" />

## 🔗 연관된 이슈

> closes #95 
