### PR TITLE
Refact/createpage v2

### DIFF
--- a/src/components/community/list/CommunitySearchBar.tsx
+++ b/src/components/community/list/CommunitySearchBar.tsx
@@ -128,8 +128,8 @@ export default function CommunitySearchBar({
             aria-haspopup="menu"
             aria-expanded={open}
           >
-            {/* 닫혀있을 때는 '검색 유형'으로 보이게 */}
-            <span>{open ? '검색 유형' : '검색 유형'}</span>
+            {/* 현재 선택된 필터 표시 */}
+            <span>{FILTER_ITEMS.find(item => item.key === filter)?.label || '검색 유형'}</span>
             <DropdownChevron open={open} />
           </button>
 

--- a/src/pages/community/CommunityCreatePage.tsx
+++ b/src/pages/community/CommunityCreatePage.tsx
@@ -303,7 +303,7 @@ export default function CommunityCreatePage() {
   }
 
 
-  const toggleLinePrefix = (prefix: string) => {
+  const toggleLinePrefix = (pattern: string | RegExp, defaultPrefix?: string) => {
     const textarea = textareaRef.current
     if (!textarea) return
 
@@ -316,16 +316,21 @@ export default function CommunityCreatePage() {
     const lines = linesContent.split('\n')
     
     const newLines = lines.map(line => {
-      if (line.startsWith(prefix)) {
-        return line.substring(prefix.length)
+      if (pattern instanceof RegExp) {
+        if (pattern.test(line)) {
+          return line.replace(pattern, '')
+        }
+        return (defaultPrefix || '') + line
       } else {
-        return prefix + line
+        if (line.startsWith(pattern)) {
+          return line.substring(pattern.length)
+        }
+        return pattern + line
       }
     })
     
     const newText = newLines.join('\n')
     
-    replaceInfo(textarea, newText, lineStart, lineEnd)
     const res = replaceInfo(textarea, newText, lineStart, lineEnd)
     updateContent(res.value)
     
@@ -336,7 +341,7 @@ export default function CommunityCreatePage() {
   }
 
   const handleOrderedList = () => {
-    toggleLinePrefix('1. ')
+    toggleLinePrefix(/^\d+\.\s/, '1. ')
     setIsListMenuOpen(false)
   }
   const handleUnorderedList = () => {
@@ -542,7 +547,7 @@ export default function CommunityCreatePage() {
                        <ToolbarArrowIcon />
                     </button>
                     
-                    <button type="button" onClick={handleUnderline} className="p-1 hover:bg-gray-100 rounded">
+                    <button type="button" onClick={() => setIsTextColorMenuOpen(!isTextColorMenuOpen)} className="p-1 hover:bg-gray-100 rounded">
                        <ToolbarTextIcon />
                     </button>
                     

--- a/src/pages/community/CommunityCreatePage.tsx
+++ b/src/pages/community/CommunityCreatePage.tsx
@@ -93,6 +93,7 @@ export default function CommunityCreatePage() {
   const fontSizeRef = useRef<HTMLDivElement>(null)
   const textColorRef = useRef<HTMLDivElement>(null)
   const listMenuRef = useRef<HTMLDivElement>(null)
+  const debounceTimerRef = useRef<NodeJS.Timeout | null>(null)
   
 
   const [historyStack, setHistoryStack] = useState<string[]>([''])
@@ -130,19 +131,15 @@ export default function CommunityCreatePage() {
 
 
   const pushToHistory = useCallback((newContent: string) => {
-    if (newContent === historyStack[historyIndex]) return 
-
-    const newHistory = historyStack.slice(0, historyIndex + 1)
-    newHistory.push(newContent)
-    
-
-    if (newHistory.length > 50) {
-      newHistory.shift()
-    }
-    
-    setHistoryStack(newHistory)
-    setHistoryIndex(newHistory.length - 1)
-  }, [historyStack, historyIndex])
+    setHistoryStack(prevStack => {
+      if (newContent === prevStack[historyIndex]) return prevStack
+      const newHistory = prevStack.slice(0, historyIndex + 1)
+      newHistory.push(newContent)
+      if (newHistory.length > 50) newHistory.shift()
+      return newHistory
+    })
+    setHistoryIndex(prevIndex => Math.min(49, prevIndex + 1))
+  }, [historyIndex])
 
   const handleUndo = () => {
     if (historyIndex > 0) {
@@ -160,11 +157,15 @@ export default function CommunityCreatePage() {
     }
   }
 
-
-  const updateContent = (newContent: string, saveToHistory = true) => {
+  const updateContent = (newContent: string, saveToHistory = true, isKeystroke = false) => {
     setContent(newContent)
     if (saveToHistory) {
-      pushToHistory(newContent)
+      if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current)
+      if (isKeystroke) {
+        debounceTimerRef.current = setTimeout(() => pushToHistory(newContent), 500)
+      } else {
+        pushToHistory(newContent)
+      }
     }
   }
 
@@ -197,19 +198,46 @@ export default function CommunityCreatePage() {
 
   const toggleWrapper = (prefix: string, suffix: string, placeholder = 'text') => {
     applyParams((sel) => {
-      if (sel.startsWith(prefix) && sel.endsWith(suffix)) {
+      const trimmed = sel.trim()
+      const leading = sel.match(/^\s*/)?.[0] || ''
+      const trailing = sel.match(/\s*$/)?.[0] || ''
+
+      // 리스트 접두사가 포함된 경우 분리 처리
+      const listMatch = trimmed.match(/^(\d+\.\s|- |> )/)
+      if (listMatch) {
+        const listPrefix = listMatch[0]
+        const body = trimmed.slice(listPrefix.length)
+        
+        if (body.startsWith(prefix) && body.endsWith(suffix)) {
+          const inner = body.slice(prefix.length, -suffix.length)
+          return {
+            text: leading + listPrefix + inner + trailing,
+            selectLength: inner.length,
+            cursorOffset: leading.length + listPrefix.length
+          }
+        }
+        const content = body || placeholder
+        return {
+          text: leading + listPrefix + prefix + content + suffix + trailing,
+          selectLength: content.length,
+          cursorOffset: leading.length + listPrefix.length + prefix.length
+        }
+      }
+
+      if (trimmed.startsWith(prefix) && trimmed.endsWith(suffix)) {
+        const inner = trimmed.slice(prefix.length, -suffix.length)
         return { 
-          text: sel.slice(prefix.length, -suffix.length),
-          selectLength: sel.length - prefix.length - suffix.length,
-          cursorOffset: 0
+          text: leading + inner + trailing,
+          selectLength: inner.length,
+          cursorOffset: leading.length
         }
       }
       
-      const content = sel || placeholder
+      const content = trimmed || placeholder
       return { 
-        text: `${prefix}${content}${suffix}`, 
+        text: leading + prefix + content + suffix + trailing, 
         selectLength: content.length,
-        cursorOffset: prefix.length 
+        cursorOffset: leading.length + prefix.length 
       }
     })
   }
@@ -432,6 +460,53 @@ export default function CommunityCreatePage() {
     }
   }
 
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    const textarea = textareaRef.current
+    if (!textarea) return
+    const { start, end, value } = getSelectionInfo(textarea)
+
+    if (e.key === 'Tab') {
+      e.preventDefault()
+      if (e.shiftKey) {
+        handleOutdent()
+      } else {
+        const res = replaceInfo(textarea, '  ', start, start)
+        updateContent(res.value)
+        setTimeout(() => {
+          textarea.selectionStart = textarea.selectionEnd = start + 2
+        }, 0)
+      }
+    }
+
+    if (e.key === 'Enter') {
+      const lineStart = value.lastIndexOf('\n', start - 1) + 1
+      const lineContent = value.substring(lineStart, start)
+
+      const listMatch = lineContent.match(/^(\s*)(\d+\.\s|- |> )/)
+      if (listMatch && lineContent.length > listMatch[0].length) {
+        e.preventDefault()
+        let nextPrefix = listMatch[0]
+        if (nextPrefix.includes('.')) {
+          const num = parseInt(nextPrefix)
+          nextPrefix = nextPrefix.replace(/\d+/, (num + 1).toString())
+        }
+        const insertText = '\n' + nextPrefix
+        const res = replaceInfo(textarea, insertText, start, start)
+        updateContent(res.value)
+        setTimeout(() => {
+          textarea.selectionStart = textarea.selectionEnd = start + insertText.length
+        }, 0)
+      } else if (listMatch && lineContent.length === listMatch[0].length) {
+        e.preventDefault()
+        const res = replaceInfo(textarea, '\n', lineStart, start)
+        updateContent(res.value)
+        setTimeout(() => {
+          textarea.selectionStart = textarea.selectionEnd = lineStart + 1
+        }, 0)
+      }
+    }
+  }
+
   return (
     <div className="flex w-full items-center justify-center py-[52px]">
       <div className="flex w-[944px] flex-col items-end gap-[52px]">
@@ -621,7 +696,7 @@ export default function CommunityCreatePage() {
                    <button type="button" onClick={() => handleAlign('justify')} className="p-1 hover:bg-gray-100 rounded"><ToolbarAlignJustifyIcon /></button>
                  </div>
 
- 
+  
                  <div className="flex items-center gap-2">
                     <button type="button" onClick={handleLineHeight} className="p-1 hover:bg-gray-100 rounded">
                        <ToolbarLineHeightIcon />
@@ -650,7 +725,8 @@ export default function CommunityCreatePage() {
                 <textarea
                   ref={textareaRef}
                   value={content}
-                  onChange={(e) => updateContent(e.target.value)}
+                  onChange={(e) => updateContent(e.target.value, true, true)}
+                  onKeyDown={handleKeyDown}
                   className="flex-1 resize-none bg-transparent font-['Pretendard'] text-[14px] leading-relaxed text-black outline-none placeholder:text-gray-300"
                   placeholder={`# 제목
 
@@ -688,8 +764,18 @@ export default function CommunityCreatePage() {
                             <code className="bg-gray-100 rounded px-1.5 py-0.5 font-mono text-sm text-red-500" {...props} />
                           ),
                        pre: ({node, ...props}) => <pre className="bg-gray-900 text-white p-4 rounded-lg overflow-x-auto my-4" {...props} />,
-                       span: ({node, ...props}) => <span {...props} />,
-                       div: ({node, ...props}) => <div {...props} />,
+                        span: ({style, ...props}) => {
+                          const styleObj = typeof style === 'string' 
+                            ? Object.fromEntries(style.split(';').filter(Boolean).map((s: string) => s.split(':').map((x: string) => x.trim())))
+                            : style
+                          return <span style={styleObj as React.CSSProperties} {...props} />
+                        },
+                        div: ({style, ...props}) => {
+                          const styleObj = typeof style === 'string'
+                            ? Object.fromEntries(style.split(';').filter(Boolean).map((s: string) => s.split(':').map((x: string) => x.trim())))
+                            : style
+                          return <div style={styleObj as React.CSSProperties} {...props} />
+                        },
                      }}
                    >
                      {content || '*미리보기가 여기에 표시됩니다.*'}

--- a/src/pages/community/CommunityEditPage.tsx
+++ b/src/pages/community/CommunityEditPage.tsx
@@ -59,7 +59,7 @@ function replaceInfo(
 }
 
 
-export default function CommunityCreatePage() {
+export default function CommunityEditPage() {
   const navigate = useNavigate()
   const { postId } = useParams<{ postId?: string }>()
   const isEditMode = Boolean(postId)
@@ -325,7 +325,7 @@ export default function CommunityCreatePage() {
   }
 
 
-  const toggleLinePrefix = (prefix: string) => {
+  const toggleLinePrefix = (pattern: string | RegExp, defaultPrefix?: string) => {
     const textarea = textareaRef.current
     if (!textarea) return
 
@@ -338,16 +338,21 @@ export default function CommunityCreatePage() {
     const lines = linesContent.split('\n')
     
     const newLines = lines.map(line => {
-      if (line.startsWith(prefix)) {
-        return line.substring(prefix.length)
+      if (pattern instanceof RegExp) {
+        if (pattern.test(line)) {
+          return line.replace(pattern, '')
+        }
+        return (defaultPrefix || '') + line
       } else {
-        return prefix + line
+        if (line.startsWith(pattern)) {
+          return line.substring(pattern.length)
+        }
+        return pattern + line
       }
     })
     
     const newText = newLines.join('\n')
     
-    replaceInfo(textarea, newText, lineStart, lineEnd)
     const res = replaceInfo(textarea, newText, lineStart, lineEnd)
     updateContent(res.value)
     
@@ -358,7 +363,7 @@ export default function CommunityCreatePage() {
   }
 
   const handleOrderedList = () => {
-    toggleLinePrefix('1. ')
+    toggleLinePrefix(/^\d+\.\s/, '1. ')
     setIsListMenuOpen(false)
   }
   const handleUnorderedList = () => {
@@ -590,7 +595,7 @@ export default function CommunityCreatePage() {
                        <ToolbarArrowIcon />
                     </button>
                     
-                    <button type="button" onClick={handleUnderline} className="p-1 hover:bg-gray-100 rounded">
+                    <button type="button" onClick={() => setIsTextColorMenuOpen(!isTextColorMenuOpen)} className="p-1 hover:bg-gray-100 rounded">
                        <ToolbarTextIcon />
                     </button>
                     

--- a/src/pages/community/CommunityEditPage.tsx
+++ b/src/pages/community/CommunityEditPage.tsx
@@ -90,6 +90,7 @@ export default function CommunityEditPage() {
 
   const [historyStack, setHistoryStack] = useState<string[]>([''])
   const [historyIndex, setHistoryIndex] = useState(0)
+  const debounceTimerRef = useRef<NodeJS.Timeout | null>(null)
 
 
   // 카테고리 목록 불러오기
@@ -152,19 +153,15 @@ export default function CommunityEditPage() {
 
 
   const pushToHistory = useCallback((newContent: string) => {
-    if (newContent === historyStack[historyIndex]) return 
-
-    const newHistory = historyStack.slice(0, historyIndex + 1)
-    newHistory.push(newContent)
-    
-
-    if (newHistory.length > 50) {
-      newHistory.shift()
-    }
-    
-    setHistoryStack(newHistory)
-    setHistoryIndex(newHistory.length - 1)
-  }, [historyStack, historyIndex])
+    setHistoryStack(prevStack => {
+      if (newContent === prevStack[historyIndex]) return prevStack
+      const newHistory = prevStack.slice(0, historyIndex + 1)
+      newHistory.push(newContent)
+      if (newHistory.length > 50) newHistory.shift()
+      return newHistory
+    })
+    setHistoryIndex(prevIndex => Math.min(49, prevIndex + 1))
+  }, [historyIndex])
 
   const handleUndo = () => {
     if (historyIndex > 0) {
@@ -182,11 +179,15 @@ export default function CommunityEditPage() {
     }
   }
 
-
-  const updateContent = (newContent: string, saveToHistory = true) => {
+  const updateContent = (newContent: string, saveToHistory = true, isKeystroke = false) => {
     setContent(newContent)
     if (saveToHistory) {
-      pushToHistory(newContent)
+      if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current)
+      if (isKeystroke) {
+        debounceTimerRef.current = setTimeout(() => pushToHistory(newContent), 500)
+      } else {
+        pushToHistory(newContent)
+      }
     }
   }
 
@@ -219,19 +220,46 @@ export default function CommunityEditPage() {
 
   const toggleWrapper = (prefix: string, suffix: string, placeholder = 'text') => {
     applyParams((sel) => {
-      if (sel.startsWith(prefix) && sel.endsWith(suffix)) {
+      const trimmed = sel.trim()
+      const leading = sel.match(/^\s*/)?.[0] || ''
+      const trailing = sel.match(/\s*$/)?.[0] || ''
+
+      // 리스트 접두사가 포함된 경우 분리 처리
+      const listMatch = trimmed.match(/^(\d+\.\s|- |> )/)
+      if (listMatch) {
+        const listPrefix = listMatch[0]
+        const body = trimmed.slice(listPrefix.length)
+        
+        if (body.startsWith(prefix) && body.endsWith(suffix)) {
+          const inner = body.slice(prefix.length, -suffix.length)
+          return {
+            text: leading + listPrefix + inner + trailing,
+            selectLength: inner.length,
+            cursorOffset: leading.length + listPrefix.length
+          }
+        }
+        const content = body || placeholder
+        return {
+          text: leading + listPrefix + prefix + content + suffix + trailing,
+          selectLength: content.length,
+          cursorOffset: leading.length + listPrefix.length + prefix.length
+        }
+      }
+
+      if (trimmed.startsWith(prefix) && trimmed.endsWith(suffix)) {
+        const inner = trimmed.slice(prefix.length, -suffix.length)
         return { 
-          text: sel.slice(prefix.length, -suffix.length),
-          selectLength: sel.length - prefix.length - suffix.length,
-          cursorOffset: 0
+          text: leading + inner + trailing,
+          selectLength: inner.length,
+          cursorOffset: leading.length
         }
       }
       
-      const content = sel || placeholder
+      const content = trimmed || placeholder
       return { 
-        text: `${prefix}${content}${suffix}`, 
+        text: leading + prefix + content + suffix + trailing, 
         selectLength: content.length,
-        cursorOffset: prefix.length 
+        cursorOffset: leading.length + prefix.length 
       }
     })
   }
@@ -471,6 +499,53 @@ export default function CommunityEditPage() {
     }
   }
 
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    const textarea = textareaRef.current
+    if (!textarea) return
+    const { start, end, value } = getSelectionInfo(textarea)
+
+    if (e.key === 'Tab') {
+      e.preventDefault()
+      if (e.shiftKey) {
+        handleOutdent()
+      } else {
+        const res = replaceInfo(textarea, '  ', start, start)
+        updateContent(res.value)
+        setTimeout(() => {
+          textarea.selectionStart = textarea.selectionEnd = start + 2
+        }, 0)
+      }
+    }
+
+    if (e.key === 'Enter') {
+      const lineStart = value.lastIndexOf('\n', start - 1) + 1
+      const lineContent = value.substring(lineStart, start)
+
+      const listMatch = lineContent.match(/^(\s*)(\d+\.\s|- |> )/)
+      if (listMatch && lineContent.length > listMatch[0].length) {
+        e.preventDefault()
+        let nextPrefix = listMatch[0]
+        if (nextPrefix.includes('.')) {
+          const num = parseInt(nextPrefix)
+          nextPrefix = nextPrefix.replace(/\d+/, (num + 1).toString())
+        }
+        const insertText = '\n' + nextPrefix
+        const res = replaceInfo(textarea, insertText, start, start)
+        updateContent(res.value)
+        setTimeout(() => {
+          textarea.selectionStart = textarea.selectionEnd = start + insertText.length
+        }, 0)
+      } else if (listMatch && lineContent.length === listMatch[0].length) {
+        e.preventDefault()
+        const res = replaceInfo(textarea, '\n', lineStart, start)
+        updateContent(res.value)
+        setTimeout(() => {
+          textarea.selectionStart = textarea.selectionEnd = lineStart + 1
+        }, 0)
+      }
+    }
+  }
+
   // 로딩 중일 때
   if (isLoadingPost) {
     return (
@@ -669,7 +744,7 @@ export default function CommunityEditPage() {
                    <button type="button" onClick={() => handleAlign('justify')} className="p-1 hover:bg-gray-100 rounded"><ToolbarAlignJustifyIcon /></button>
                  </div>
 
- 
+  
                  <div className="flex items-center gap-2">
                     <button type="button" onClick={handleLineHeight} className="p-1 hover:bg-gray-100 rounded">
                        <ToolbarLineHeightIcon />
@@ -698,7 +773,8 @@ export default function CommunityEditPage() {
                 <textarea
                   ref={textareaRef}
                   value={content}
-                  onChange={(e) => updateContent(e.target.value)}
+                  onChange={(e) => updateContent(e.target.value, true, true)}
+                  onKeyDown={handleKeyDown}
                   className="flex-1 resize-none bg-transparent font-['Pretendard'] text-[14px] leading-relaxed text-black outline-none placeholder:text-gray-300"
                   placeholder={`# 제목
 
@@ -736,8 +812,18 @@ export default function CommunityEditPage() {
                             <code className="bg-gray-100 rounded px-1.5 py-0.5 font-mono text-sm text-red-500" {...props} />
                           ),
                        pre: ({node, ...props}) => <pre className="bg-gray-900 text-white p-4 rounded-lg overflow-x-auto my-4" {...props} />,
-                       span: ({node, ...props}) => <span {...props} />,
-                       div: ({node, ...props}) => <div {...props} />,
+                        span: ({style, ...props}) => {
+                          const styleObj = typeof style === 'string' 
+                            ? Object.fromEntries(style.split(';').filter(Boolean).map((s: string) => s.split(':').map((x: string) => x.trim())))
+                            : style
+                          return <span style={styleObj as React.CSSProperties} {...props} />
+                        },
+                        div: ({style, ...props}) => {
+                          const styleObj = typeof style === 'string'
+                            ? Object.fromEntries(style.split(';').filter(Boolean).map((s: string) => s.split(':').map((x: string) => x.trim())))
+                            : style
+                          return <div style={styleObj as React.CSSProperties} {...props} />
+                        },
                      }}
                    >
                      {content || '*미리보기가 여기에 표시됩니다.*'}


### PR DESCRIPTION
## 🚀 PR 요약

수정 / 작성 페이지 기능 수정

## ✏️ 변경 유형

- [ ] feat: 새로운 기능 추가
- [ ] fix: 버그 수정
- [ ] docs: 문서 수정
- [ ] style: 코드 포맷팅 등 스타일 변경
- [v] refact: 코드 리팩토링
- [ ] test: 테스트 코드 추가/수정
- [ ] chore: 기타 변경사항

## ✅ 체크리스트

- [v] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [ ] 커밋에 관련된 이슈 번호를 포함했습니다.
- [v] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 상세 내용 (선택)

### 작업 사항

아이콘 기능 수정: 텍스트 컬러 섹션에 있던 ToolbarTextIcon 버튼이 기존에는 '밑줄(Underline)' 기능으로 연결되어 있었으나, 이제 컬러 선택 메뉴를 열도록 수정했습니다.

중복 코드 제거: toggleLinePrefix 함수 내에서 replaceInfo를 불필요하게 두 번 호출하던 로직을 하나로 정리하여 성능과 안정성을 높였습니다.

리스트/색상 버그 수정:  이전에는 리스트(-, 1.) 형식에서 글자 색상을 바꾸면 리스트 기호가 사라지거나 이상하게 변하는 문제가 있었는데, 이제는 형식이 그대로 유지되면서 색상만 깔끔하게 바뀝니다.

똑똑해진 엔터(Enter) 키 :  리스트나 인용문(> )을 작성하다가 엔터 키를 누르면, 다음 줄에도 자동으로 리스트 기호나 인용문 기호가 붙어서 연속해서 작성하기가 훨씬 편해졌습니다.

탭(Tab) 키 지원:  키보드의 Tab 키로 들여쓰기를 할 수 있고, Shift + Tab을 누르면 내어쓰기도 가능하여 글의 구조를 잡기 쉬워졌습니다.

작업 취소/다시 행 개선 (Undo/Redo):
글을 쓰다가 되돌리거나(Ctrl+Z) 다시 실행할 때 훨씬 부드럽게 작동하도록 성능을 최적화했습니다.

미리보기 스타일 완벽 반영:
미리보기 화면에서 글자 색상, 크기, 자간 등이 실제 게시글과 똑같이 보이도록 렌더링 문제를 해결했습니다.

컴포넌트 명칭 수정 (덤):   CommunityEditPage.tsx 파일 내에서 컴포넌트 이름이 CommunityCreatePage로 잘못 선언되어 있던 부분도 함께 바로잡았습니다.


