### PR TITLE
Fix/createpage bold 에러 수정

### DIFF
--- a/src/pages/community/CommunityCreatePage.tsx
+++ b/src/pages/community/CommunityCreatePage.tsx
@@ -206,11 +206,11 @@ export default function CommunityCreatePage() {
 
   const toggleWrapper = (prefix: string, suffix: string, placeholder = 'text') => {
     applyParams((sel, all, start, end) => {
-      // 1. 이미 선택 영역 외부가 기호로 감싸져 있는지 확인 (예: *|abc|* )
+      // 1. 이미 선택 영역 외부가 기호로 감싸져 있는지 확인 
       const before = all.substring(start - prefix.length, start)
       const after = all.substring(end, end + suffix.length)
 
-      // Italic(*) 특수 처리: Bold(**)와 혼동되지 않도록 함
+      // Italic 특수 처리: Bold와 혼동되지 않도록 함
       let isItalicTogglingBold = false
       if (prefix === '*' && suffix === '*') {
         const furtherBefore = all.substring(start - 2, start - 1)
@@ -230,7 +230,7 @@ export default function CommunityCreatePage() {
         }
       }
 
-      // 2. 선택 영역 내부의 앞뒤 공백 및 리스트 기호 처리 (기존 로직 유지/강화)
+      // 2. 선택 영역 내부의 앞뒤 공백 및 리스트 기호 처리 
       const trimmed = sel.trim()
       const leadingGap = sel.match(/^\s*/)?.[0] || ''
       const trailingGap = sel.match(/\s*$/)?.[0] || ''
@@ -256,7 +256,7 @@ export default function CommunityCreatePage() {
         }
       }
 
-      // 3. 선택 영역 자체가 기호로 감싸져 있는 경우 (예: |*abc*| )
+      // 3. 선택 영역 자체가 기호로 감싸져 있는 경우 
       if (trimmed.startsWith(prefix) && trimmed.endsWith(suffix)) {
         // Italic vs Bold 체크
         let isInternalItalicTogglingBold = false

--- a/src/pages/community/CommunityCreatePage.tsx
+++ b/src/pages/community/CommunityCreatePage.tsx
@@ -171,15 +171,23 @@ export default function CommunityCreatePage() {
 
 
   const applyParams = (
-    transform: (sel: string, all: string, start: number, end: number) => { text: string; cursorOffset?: number; selectLength?: number }
+    transform: (sel: string, all: string, start: number, end: number) => { 
+      text: string; 
+      cursorOffset?: number; 
+      selectLength?: number;
+      rangeStart?: number;
+      rangeEnd?: number;
+    }
   ) => {
     const textarea = textareaRef.current
     if (!textarea) return
 
     const { start, end, selectedText } = getSelectionInfo(textarea)
-    const { text, cursorOffset, selectLength } = transform(selectedText, textarea.value, start, end)
+    const { text, cursorOffset, selectLength, rangeStart, rangeEnd } = transform(selectedText, textarea.value, start, end)
 
-    const result = replaceInfo(textarea, text, start, end)
+    const actualStart = rangeStart ?? start
+    const actualEnd = rangeEnd ?? end
+    const result = replaceInfo(textarea, text, actualStart, actualEnd)
     
 
     updateContent(result.value, true)
@@ -187,7 +195,7 @@ export default function CommunityCreatePage() {
 
     setTimeout(() => {
       textarea.focus()
-      const newCursorStart = start + (cursorOffset ?? text.length)
+      const newCursorStart = actualStart + (cursorOffset ?? text.length)
       const newCursorEnd = selectLength !== undefined ? newCursorStart + selectLength : newCursorStart
       textarea.selectionStart = newCursorStart
       textarea.selectionEnd = newCursorEnd
@@ -197,12 +205,36 @@ export default function CommunityCreatePage() {
   // --- 툴바  ---
 
   const toggleWrapper = (prefix: string, suffix: string, placeholder = 'text') => {
-    applyParams((sel) => {
-      const trimmed = sel.trim()
-      const leading = sel.match(/^\s*/)?.[0] || ''
-      const trailing = sel.match(/\s*$/)?.[0] || ''
+    applyParams((sel, all, start, end) => {
+      // 1. 이미 선택 영역 외부가 기호로 감싸져 있는지 확인 (예: *|abc|* )
+      const before = all.substring(start - prefix.length, start)
+      const after = all.substring(end, end + suffix.length)
 
-      // 리스트 접두사가 포함된 경우 분리 처리
+      // Italic(*) 특수 처리: Bold(**)와 혼동되지 않도록 함
+      let isItalicTogglingBold = false
+      if (prefix === '*' && suffix === '*') {
+        const furtherBefore = all.substring(start - 2, start - 1)
+        const furtherAfter = all.substring(end + 1, end + 2)
+        if (before === '*' && after === '*' && (furtherBefore === '*' || furtherAfter === '*')) {
+          isItalicTogglingBold = true
+        }
+      }
+
+      if (before === prefix && after === suffix && !isItalicTogglingBold) {
+        return {
+          text: sel,
+          rangeStart: start - prefix.length,
+          rangeEnd: end + suffix.length,
+          cursorOffset: 0,
+          selectLength: sel.length
+        }
+      }
+
+      // 2. 선택 영역 내부의 앞뒤 공백 및 리스트 기호 처리 (기존 로직 유지/강화)
+      const trimmed = sel.trim()
+      const leadingGap = sel.match(/^\s*/)?.[0] || ''
+      const trailingGap = sel.match(/\s*$/)?.[0] || ''
+
       const listMatch = trimmed.match(/^(\d+\.\s|- |> )/)
       if (listMatch) {
         const listPrefix = listMatch[0]
@@ -211,33 +243,45 @@ export default function CommunityCreatePage() {
         if (body.startsWith(prefix) && body.endsWith(suffix)) {
           const inner = body.slice(prefix.length, -suffix.length)
           return {
-            text: leading + listPrefix + inner + trailing,
+            text: leadingGap + listPrefix + inner + trailingGap,
             selectLength: inner.length,
-            cursorOffset: leading.length + listPrefix.length
+            cursorOffset: leadingGap.length + listPrefix.length
           }
         }
         const content = body || placeholder
         return {
-          text: leading + listPrefix + prefix + content + suffix + trailing,
+          text: leadingGap + listPrefix + prefix + content + suffix + trailingGap,
           selectLength: content.length,
-          cursorOffset: leading.length + listPrefix.length + prefix.length
+          cursorOffset: leadingGap.length + listPrefix.length + prefix.length
         }
       }
 
+      // 3. 선택 영역 자체가 기호로 감싸져 있는 경우 (예: |*abc*| )
       if (trimmed.startsWith(prefix) && trimmed.endsWith(suffix)) {
-        const inner = trimmed.slice(prefix.length, -suffix.length)
-        return { 
-          text: leading + inner + trailing,
-          selectLength: inner.length,
-          cursorOffset: leading.length
+        // Italic vs Bold 체크
+        let isInternalItalicTogglingBold = false
+        if (prefix === '*' && suffix === '*') {
+          if (trimmed.startsWith('**') && trimmed.endsWith('**')) {
+            isInternalItalicTogglingBold = true
+          }
+        }
+
+        if (!isInternalItalicTogglingBold) {
+          const inner = trimmed.slice(prefix.length, -suffix.length)
+          return { 
+            text: leadingGap + inner + trailingGap,
+            selectLength: inner.length,
+            cursorOffset: leadingGap.length
+          }
         }
       }
       
+      // 4. 감싸기 실행
       const content = trimmed || placeholder
       return { 
-        text: leading + prefix + content + suffix + trailing, 
+        text: leadingGap + prefix + content + suffix + trailingGap, 
         selectLength: content.length,
-        cursorOffset: leading.length + prefix.length 
+        cursorOffset: leadingGap.length + prefix.length 
       }
     })
   }

--- a/src/pages/community/CommunityEditPage.tsx
+++ b/src/pages/community/CommunityEditPage.tsx
@@ -193,15 +193,23 @@ export default function CommunityEditPage() {
 
 
   const applyParams = (
-    transform: (sel: string, all: string, start: number, end: number) => { text: string; cursorOffset?: number; selectLength?: number }
+    transform: (sel: string, all: string, start: number, end: number) => { 
+      text: string; 
+      cursorOffset?: number; 
+      selectLength?: number;
+      rangeStart?: number;
+      rangeEnd?: number;
+    }
   ) => {
     const textarea = textareaRef.current
     if (!textarea) return
 
     const { start, end, selectedText } = getSelectionInfo(textarea)
-    const { text, cursorOffset, selectLength } = transform(selectedText, textarea.value, start, end)
+    const { text, cursorOffset, selectLength, rangeStart, rangeEnd } = transform(selectedText, textarea.value, start, end)
 
-    const result = replaceInfo(textarea, text, start, end)
+    const actualStart = rangeStart ?? start
+    const actualEnd = rangeEnd ?? end
+    const result = replaceInfo(textarea, text, actualStart, actualEnd)
     
 
     updateContent(result.value, true)
@@ -209,7 +217,7 @@ export default function CommunityEditPage() {
 
     setTimeout(() => {
       textarea.focus()
-      const newCursorStart = start + (cursorOffset ?? text.length)
+      const newCursorStart = actualStart + (cursorOffset ?? text.length)
       const newCursorEnd = selectLength !== undefined ? newCursorStart + selectLength : newCursorStart
       textarea.selectionStart = newCursorStart
       textarea.selectionEnd = newCursorEnd
@@ -219,12 +227,36 @@ export default function CommunityEditPage() {
   // --- 툴바  ---
 
   const toggleWrapper = (prefix: string, suffix: string, placeholder = 'text') => {
-    applyParams((sel) => {
-      const trimmed = sel.trim()
-      const leading = sel.match(/^\s*/)?.[0] || ''
-      const trailing = sel.match(/\s*$/)?.[0] || ''
+    applyParams((sel, all, start, end) => {
+      // 1. 이미 선택 영역 외부가 기호로 감싸져 있는지 확인 (예: *|abc|* )
+      const before = all.substring(start - prefix.length, start)
+      const after = all.substring(end, end + suffix.length)
 
-      // 리스트 접두사가 포함된 경우 분리 처리
+      // Italic(*) 특수 처리: Bold(**)와 혼동되지 않도록 함
+      let isItalicTogglingBold = false
+      if (prefix === '*' && suffix === '*') {
+        const furtherBefore = all.substring(start - 2, start - 1)
+        const furtherAfter = all.substring(end + 1, end + 2)
+        if (before === '*' && after === '*' && (furtherBefore === '*' || furtherAfter === '*')) {
+          isItalicTogglingBold = true
+        }
+      }
+
+      if (before === prefix && after === suffix && !isItalicTogglingBold) {
+        return {
+          text: sel,
+          rangeStart: start - prefix.length,
+          rangeEnd: end + suffix.length,
+          cursorOffset: 0,
+          selectLength: sel.length
+        }
+      }
+
+      // 2. 선택 영역 내부의 앞뒤 공백 및 리스트 기호 처리 (기존 로직 유지/강화)
+      const trimmed = sel.trim()
+      const leadingGap = sel.match(/^\s*/)?.[0] || ''
+      const trailingGap = sel.match(/\s*$/)?.[0] || ''
+
       const listMatch = trimmed.match(/^(\d+\.\s|- |> )/)
       if (listMatch) {
         const listPrefix = listMatch[0]
@@ -233,33 +265,45 @@ export default function CommunityEditPage() {
         if (body.startsWith(prefix) && body.endsWith(suffix)) {
           const inner = body.slice(prefix.length, -suffix.length)
           return {
-            text: leading + listPrefix + inner + trailing,
+            text: leadingGap + listPrefix + inner + trailingGap,
             selectLength: inner.length,
-            cursorOffset: leading.length + listPrefix.length
+            cursorOffset: leadingGap.length + listPrefix.length
           }
         }
         const content = body || placeholder
         return {
-          text: leading + listPrefix + prefix + content + suffix + trailing,
+          text: leadingGap + listPrefix + prefix + content + suffix + trailingGap,
           selectLength: content.length,
-          cursorOffset: leading.length + listPrefix.length + prefix.length
+          cursorOffset: leadingGap.length + listPrefix.length + prefix.length
         }
       }
 
+      // 3. 선택 영역 자체가 기호로 감싸져 있는 경우 (예: |*abc*| )
       if (trimmed.startsWith(prefix) && trimmed.endsWith(suffix)) {
-        const inner = trimmed.slice(prefix.length, -suffix.length)
-        return { 
-          text: leading + inner + trailing,
-          selectLength: inner.length,
-          cursorOffset: leading.length
+        // Italic vs Bold 체크
+        let isInternalItalicTogglingBold = false
+        if (prefix === '*' && suffix === '*') {
+          if (trimmed.startsWith('**') && trimmed.endsWith('**')) {
+            isInternalItalicTogglingBold = true
+          }
+        }
+
+        if (!isInternalItalicTogglingBold) {
+          const inner = trimmed.slice(prefix.length, -suffix.length)
+          return { 
+            text: leadingGap + inner + trailingGap,
+            selectLength: inner.length,
+            cursorOffset: leadingGap.length
+          }
         }
       }
       
+      // 4. 감싸기 실행
       const content = trimmed || placeholder
       return { 
-        text: leading + prefix + content + suffix + trailing, 
+        text: leadingGap + prefix + content + suffix + trailingGap, 
         selectLength: content.length,
-        cursorOffset: leading.length + prefix.length 
+        cursorOffset: leadingGap.length + prefix.length 
       }
     })
   }


### PR DESCRIPTION
## 🚀 PR 요약
작성 , 수정 페이지에서 볼드 ,기울기 버튼 수정 
## ✏️ 변경 유형

- [ ] feat: 새로운 기능 추가
- [v] fix: 버그 수정
- [ ] docs: 문서 수정
- [ ] style: 코드 포맷팅 등 스타일 변경
- [v] refact: 코드 리팩토링
- [ ] test: 테스트 코드 추가/수정
- [ ] chore: 기타 변경사항

## ✅ 체크리스트

- [v] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [v] 커밋에 관련된 이슈 번호를 포함했습니다.
- [v] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 상세 내용 (선택)

### 작업 사항

기존에는 선택 영역 주변에 이미 기호가 있는지를 확인하지 못해 클릭할 때마다 기호가 중첩되었으나, 
이제는 기호가 있는 경우 이를 인식하고 제거(toggle off)하도록 로직을 개선했습니다. 
또한 기울기와 굵게 기호가 서로 간섭하지 않도록 특수 처리도 추가했습니다.

### 참고 사항

- 로직 개선 후 두번째 이슈도 해결 


## 🔗 연관된 이슈

> closes #111 
> closes #112 