### PR TITLE
flx/목록 페이지 마크다운 언어 오류 해결

### DIFF
--- a/src/components/community/list/CommunityListItem.tsx
+++ b/src/components/community/list/CommunityListItem.tsx
@@ -2,7 +2,7 @@
 import { useMemo } from 'react'
 import { useNavigate } from 'react-router-dom'
 import type { CommunityPostListItem } from '../../../types'
-import { formatRelativeTime } from '../../../utils/community'
+import { formatRelativeTime, stripMarkdown } from '../../../utils/community'
 
 type Props = {
   item: CommunityPostListItem
@@ -59,7 +59,7 @@ export default function CommunityListItem({ item, categoryName }: Props) {
           </div>
 
           <div className="mt-[10px] line-clamp-2 text-[14px] leading-[22px] text-[#8A8A8A]">
-            {item.content_preview}
+            {stripMarkdown(item.content_preview)}
           </div>
 
           {/* 하단 메타 */}

--- a/src/utils/community.ts
+++ b/src/utils/community.ts
@@ -1,4 +1,4 @@
-// src/utils/community.ts
+
 export function formatRelativeTime(iso: string) {
   const d = new Date(iso)
   const diff = Date.now() - d.getTime()
@@ -14,4 +14,38 @@ export function formatRelativeTime(iso: string) {
 
   const day = Math.floor(hour / 24)
   return `${day}일 전`
+}
+
+/**
+ * 마크다운 및 HTML 태그를 제거하여 순수 텍스트만 추출합니다.
+ */
+export function stripMarkdown(text: string): string {
+  if (!text) return ''
+
+  let stripped = text
+    // 0. HTML 엔티티 변환 (&lt; -> <, &gt; -> >, &nbsp; -> 공백 등)
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    // 1. HTML 태그 제거 (완성된 태그 및 잘린 태그 <span... 도 처리)
+    .replace(/<[^>]*>?/g, '')
+    // 2. 이미지 제거 ![alt](url) -> alt
+    .replace(/!\[([^\]]*)\]\([^)]*\)/g, '$1')
+    // 3. 링크 제거 [text](url) -> text
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
+    // 4. Bold/Italic 제거 (***, **, *, ___, __, _)
+    .replace(/(\*{1,3}|_{1,3})(.*?)\1/g, '$2')
+    // 5. 취소선 제거 ~~text~~ -> text
+    .replace(/~~(.*?)~~/g, '$1')
+    // 6. 코드 블록/인라인 코드 제거
+    .replace(/`{1,3}(.*?)\1/gs, '$1')
+    // 7. 남은 특수 문자 정리 (#, >, -, + 등 줄 시작 기호)
+    .replace(/^[#>\-\+\*\s]+/gm, '')
+    // 8. 여러 개의 줄바꿈을 공백으로 변경
+    .replace(/\n+/g, ' ')
+    .trim()
+
+  return stripped
 }


### PR DESCRIPTION
## 🚀 PR 요약

목록 페이지 마크다운 언어 오류 해결

## ✏️ 변경 유형

- [ ] feat: 새로운 기능 추가
- [v] fix: 버그 수정
- [ ] docs: 문서 수정
- [ ] style: 코드 포맷팅 등 스타일 변경
- [ ] refact: 코드 리팩토링
- [ ] test: 테스트 코드 추가/수정
- [ ] chore: 기타 변경사항

## ✅ 체크리스트

- [v] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [ ]커밋에 관련된 이슈 번호를 포함했습니다.
- [v] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 상세 내용 (선택)

### 작업 사항

stripMarkdown 유틸리티 추가

잘린 태그 처리: 태그가 완전히 닫히지 않았더라도 <로 시작하는 부분을 더 공격적으로 제거하도록 정규식을 수정

HTML 엔티티 대응: 만약 서버에서 인코딩된 형태로 내려줄 경우에도 대응할 수 있도록 변환 로직을 추가

목록 아이템 적용


