### PR TITLE
fix:리스트 페이지 미리보기 대체 텍스트 추가

### DIFF
--- a/src/components/community/list/CommunityListItem.tsx
+++ b/src/components/community/list/CommunityListItem.tsx
@@ -59,7 +59,7 @@ export default function CommunityListItem({ item, categoryName }: Props) {
           </div>
 
           <div className="mt-[10px] line-clamp-2 text-[14px] leading-[22px] text-[#8A8A8A]">
-            {stripMarkdown(item.content_preview)}
+            {stripMarkdown(item.content_preview) || '본문 미리보기가 없습니다.'}
           </div>
 
           {/* 하단 지표 (좋아요, 댓글, 조회수) */}

--- a/src/pages/community/CommunityEditPage.tsx
+++ b/src/pages/community/CommunityEditPage.tsx
@@ -252,7 +252,7 @@ export default function CommunityEditPage() {
         }
       }
 
-      // 2. 선택 영역 내부의 앞뒤 공백 및 리스트 기호 처리 (기존 로직 유지/강화)
+      // 2. 선택 영역 내부의 앞뒤 공백 및 리스트 기호 처리
       const trimmed = sel.trim()
       const leadingGap = sel.match(/^\s*/)?.[0] || ''
       const trailingGap = sel.match(/\s*$/)?.[0] || ''
@@ -546,7 +546,7 @@ export default function CommunityEditPage() {
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     const textarea = textareaRef.current
     if (!textarea) return
-    const { start, end, value } = getSelectionInfo(textarea)
+    const { start, value } = getSelectionInfo(textarea)
 
     if (e.key === 'Tab') {
       e.preventDefault()


### PR DESCRIPTION
## 🚀 PR 요약

백엔드 html 파싱오류로 인한 미리보기 오류는
<img width="1369" height="505" alt="image" src="https://github.com/user-attachments/assets/e198b1d8-1bf5-4e09-b3f4-261c4191df00" />
위와 같이  반환 값이 null인 경우에만 대체 텍스트로 대체 하였습니다

## ✏️ 변경 유형

- [ ] feat: 새로운 기능 추가
- [v] fix: 버그 수정
- [ ] docs: 문서 수정
- [ ] style: 코드 포맷팅 등 스타일 변경
- [ ] refact: 코드 리팩토링
- [ ] test: 테스트 코드 추가/수정
- [ ] chore: 기타 변경사항

## ✅ 체크리스트

- [v] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [v] 커밋에 관련된 이슈 번호를 포함했습니다.
- [v] 실행에 문제가 없는지 테스트했습니다.


## 🔗 연관된 이슈

> closes #115  <- 이번에 작업한 이슈 번호
