### PR TITLE
fix : 좋아요 카운트 문제 해결

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -85,10 +85,21 @@ export async function getCommunityPosts(
 ): Promise<PaginatedResponse<CommunityPostListItem>> {
   const q = toQuery(params as unknown as Record<string, unknown>)
   const suffix = q.toString() ? `?${q.toString()}` : ''
-  const res = await api.get<PaginatedResponse<CommunityPostListItem>>(
+  const res = await api.get<PaginatedResponse<any>>(
     `/api/v1/posts/${suffix}`
   )
-  return res.data
+  
+  // 서버 응답(like_count)을 프론트엔드 형식(likes_count)으로 변환
+  const transformedResults = (res.data.results || []).map((item: any) => ({
+    ...item,
+    likes_count: item.likes_count ?? item.like_count ?? 0,
+    comments_count: item.comments_count ?? item.comment_count ?? 0,
+  }))
+
+  return {
+    ...res.data,
+    results: transformedResults,
+  }
 }
 
 export async function createCommunityPost(
@@ -107,10 +118,18 @@ export async function getCommunityPostDetail(
   postId: number
 ): Promise<CommunityPostDetail> {
   const token = getAccessToken()
-  const res = await api.get<CommunityPostDetail>(`/api/v1/posts/${postId}`, {
+  const res = await api.get<any>(`/api/v1/posts/${postId}`, {
     headers: { ...withAuth(token || undefined) }
   })
-  return res.data
+  
+  const data = res.data
+  // 서버 응답 필드 맵핑 (like_count -> likes_count, is_liked -> is_like 등)
+  return {
+    ...data,
+    likes_count: data.likes_count ?? data.like_count ?? 0,
+    comments_count: data.comments_count ?? data.comment_count ?? 0,
+    is_like: data.is_like ?? data.is_liked ?? false,
+  }
 }
 
 export async function updateCommunityPost(


### PR DESCRIPTION
## 🚀 PR 요약

좋아요 카운트 문제를 해결하였습니다

## ✏️ 변경 유형

- [ ] feat: 새로운 기능 추가
- [ ] fix: 버그 수정
- [ ] docs: 문서 수정
- [ ] style: 코드 포맷팅 등 스타일 변경
- [ ] refact: 코드 리팩토링
- [ ] test: 테스트 코드 추가/수정
- [ ] chore: 기타 변경사항

## ✅ 체크리스트

- [ ] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [ ] 커밋에 관련된 이슈 번호를 포함했습니다.
- [ ] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 상세 내용 (선택)

### 작업 사항

좋아요 개수 무너짐과 새로고침 시 초기화되는 문제의 근본 원인을 해결했습니다.

원인 분석: 우리 서비스는 likes_count라는 이름을 쓰기로 했지만, 실제 서버는 여전히 like_count라는 이름을 보내주고 있었습니다. 
이 이름 차이 때문에 프론트엔드가 데이터를 찾지 못해 "좋아요 0"으로 초기화되거나 리스트에서 숫자가 안 보였던 것

해결 내용: 
데이터 자동 변환(Mapping): api.ts에서 서버 응답을 받을 때, 서버가 보내주는 이름(like_count, is_liked)을 우리 프론트엔드 이름(likes_count, is_like)으로 자동 변환하도록 로직을 추가

안정성 확보: 이제 서버가 어떤 이름을 보내더라도 프론트엔드는 정상적으로 likes_count를 사용하여 숫자를 보여주고, 새로고침 시에도 데이터가 유지됩니다.

음수 방지: 좋아요가 -1이 되지 않도록 0 미만 방어 로직을 한 번 더 확인했습니다.


