### PR TITLE
feat: 커뮤니티 리스트 페이지 프로필 이미지

### DIFF
--- a/src/components/community/list/CommunityListItem.tsx
+++ b/src/components/community/list/CommunityListItem.tsx
@@ -30,36 +30,42 @@ function LikeThumbIcon() {
 
 export default function CommunityListItem({ item, categoryName }: Props) {
   const nav = useNavigate()
+
   const timeText = useMemo(
     () => formatRelativeTime(item.created_at),
     [item.created_at]
   )
-  
-  // 썸네일 URL 추출
+
+  //프로필 이미지
+const profileUrl = useMemo(() => {
+  const url = item.author.profile_img_url
+
+  if (
+    !url ||
+    url === 'null' ||
+    url === 'None' ||
+    url.includes('null') ||
+    url.includes('None')
+  ) {
+    return '/icons/profile.svg'
+  }
+
+  return url
+}, [item.author.profile_img_url])
+
+  // 썸네일 로직은 그대로 유지 (건드리지 않음)
   const thumbnailUrl = useMemo(() => {
-    // 1. API에서 제공한 thumbnail_img_url 우선
-    if (item.thumbnail_img_url) {
-      console.log('Using API thumbnail:', item.thumbnail_img_url)
-      return item.thumbnail_img_url
-    }
-    
-    // 2. content_preview에서 이미지 추출 시도
-    if (item.content_preview) {
-      const extracted = extractFirstImageUrl(item.content_preview)
-      console.log('Extracted from content_preview:', extracted)
-      return extracted
-    }
-    
+    if (item.thumbnail_img_url) return item.thumbnail_img_url
+    if (item.content_preview) return extractFirstImageUrl(item.content_preview)
     return null
   }, [item.thumbnail_img_url, item.content_preview])
-  
+
   const hasThumb = Boolean(thumbnailUrl)
 
   return (
     <button
       type="button"
       onClick={() => {
-        console.log('Item clicked, ID:', item.id, 'Thumbnail:', thumbnailUrl)
         nav(`/community/${item.id}`, {
           state: { thumbnail_img_url: thumbnailUrl },
         })
@@ -67,7 +73,8 @@ export default function CommunityListItem({ item, categoryName }: Props) {
       className="w-full text-left"
     >
       <div className="flex w-full items-start justify-between gap-[32px] px-[24px] py-[32px]">
-        {/* 왼쪽: 게시글 핵심 내용 구역 */}
+        
+        {/* 왼쪽 영역 */}
         <div className="min-w-0 flex-1">
           <div className="text-[12px] font-medium text-[#8A8A8A]">
             {categoryName}
@@ -77,29 +84,25 @@ export default function CommunityListItem({ item, categoryName }: Props) {
             {item.title}
           </div>
 
-          {/* 하단 지표 (좋아요, 댓글, 조회수) */}
           <div className="mt-[54px] flex items-center gap-[14px] text-[12px] text-[#8A8A8A]">
             <span className="inline-flex items-center gap-[6px]">
               <LikeThumbIcon />
               <span>좋아요 {item.likes_count}</span>
             </span>
-            <span className="inline-flex items-center gap-[6px]">
-              <span>댓글 {item.comments_count}</span>
-            </span>
-            <span className="inline-flex items-center gap-[6px]">
-              <span>조회수 {item.view_count}</span>
-            </span>
+            <span>댓글 {item.comments_count}</span>
+            <span>조회수 {item.view_count}</span>
           </div>
         </div>
 
-        {/* 오른쪽 영역 (작성자 구역 + 썸네일 구역)*/}
+        {/* 오른쪽 영역 */}
         <div className="flex-shrink-0 flex items-end gap-[20px] self-stretch">
-          {/* 작성자 정보 (닉네임 + 시간) */}
+          
+          {/* 👤 작성자 정보 */}
           <div className="flex items-center gap-[10px] text-[12px] text-[#8A8A8A] mb-[2px]">
             <img
-              src={item.author.profile_img_url || '/icons/profil.svg'}
+              src={profileUrl}
               alt={`${item.author.nickname} 프로필`}
-              className="h-[24px] w-[24px] overflow-hidden rounded-full object-cover bg-[#EDEDED]"
+              className="h-[24px] w-[24px] rounded-full object-cover bg-[#EDEDED]"
               onError={(e) => {
                 e.currentTarget.src = '/icons/profil.svg'
               }}
@@ -110,30 +113,23 @@ export default function CommunityListItem({ item, categoryName }: Props) {
             </div>
           </div>
 
-          {/* 썸네일 이미지 구역 - 이미지가 있을 때만 표시 */}
+          {/* 썸네일 */}
           {hasThumb && (
-            <div className="flex-shrink-0">
-              <div className="h-[160px] w-[200px] overflow-hidden rounded-[12px] bg-[#F2F2F2]">
-                <img
-                  alt="thumbnail"
-                  src={thumbnailUrl ?? ''}
-                  className="h-full w-full object-cover"
-                  loading="lazy"
-                  onError={(e) => {
-                    console.error('Image load failed:', thumbnailUrl)
-                    e.currentTarget.style.display = 'none'
-                  }}
-                  onLoad={() => {
-                    console.log('Image loaded successfully:', thumbnailUrl)
-                  }}
-                />
-              </div>
+            <div className="h-[160px] w-[200px] overflow-hidden rounded-[12px] bg-[#F2F2F2]">
+              <img
+                alt="thumbnail"
+                src={thumbnailUrl ?? ''}
+                className="h-full w-full object-cover"
+                loading="lazy"
+                onError={(e) => {
+                  e.currentTarget.style.display = 'none'
+                }}
+              />
             </div>
           )}
         </div>
       </div>
 
-      {/* 구분선 */}
       <div className="mx-[24px] h-[1px] bg-[#EDEDED]" />
     </button>
   )


### PR DESCRIPTION
## 🚀 PR 요약

> 커뮤니티 리스트 페이지 프로필 이미지 적용했습니다.

## ✏️ 변경 유형

- [x] feat: 새로운 기능 추가
- [ ] fix: 버그 수정
- [ ] docs: 문서 수정
- [ ] style: 코드 포맷팅 등 스타일 변경
- [ ] refact: 코드 리팩토링
- [ ] test: 테스트 코드 추가/수정
- [ ] chore: 기타 변경사항

## ✅ 체크리스트

- [x] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [x] 커밋에 관련된 이슈 번호를 포함했습니다.
- [x] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 상세 내용 (선택)

### 작업 사항

- 커뮤니티 리스트 페이지 프로필 이미지 적용

### 스크린 샷

<img width="1329" height="763" alt="스크린샷 2026-02-10 오후 5 46 31" src="https://github.com/user-attachments/assets/08f64196-c937-4c01-b88d-912ba2335f95" />

## 🔗 연관된 이슈

> closes #154

