### PR TITLE
feat: 검색어 디바운싱

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,2 +1,3 @@
 //hooks
 export * from './useInfiniteScroll'
+export * from './useDebounce'

--- a/src/hooks/useDebounce.ts
+++ b/src/hooks/useDebounce.ts
@@ -1,0 +1,17 @@
+import { useEffect, useState } from 'react'
+
+export function useDebounce<T>(value: T, delay: number): T {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value)
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedValue(value)
+    }, delay)
+
+    return () => {
+      clearTimeout(timer)
+    }
+  }, [value, delay])
+
+  return debouncedValue
+}

--- a/src/pages/community/CommunityListPage.tsx
+++ b/src/pages/community/CommunityListPage.tsx
@@ -5,7 +5,7 @@ import { motion } from 'framer-motion'
 import CommunityListItem from '../../components/community/list/CommunityListItem'
 import CommunitySearchBar from '../../components/community/list/CommunitySearchBar'
 import { communityApi } from '../../api/api'
-import { useInfiniteScroll } from '../../hooks'
+import { useInfiniteScroll, useDebounce } from '../../hooks'
 import type {
   CommunityCategory,
   CommunityPostListItem,
@@ -120,6 +120,7 @@ export default function CommunityListPage() {
   
   const [filter, setFilter] = useState<SearchFilterOption>('all')
   const [keyword, setKeyword] = useState('')
+  const debouncedKeyword = useDebounce(keyword, 500)
 
   // 정렬
   const [sortKey, setSortKey] = useState<SortKey>('latest')
@@ -203,7 +204,7 @@ export default function CommunityListPage() {
   // 필터나 카테고리 변경 시 초기화
   useEffect(() => {
     fetchPosts(1, true)
-  }, [selectedCategoryId, keyword, filter, sortKey])
+  }, [selectedCategoryId, debouncedKeyword, filter, sortKey])
 
   // 무한 스크롤 커스텀 훅 적용
   const observerRef = useInfiniteScroll({


### PR DESCRIPTION
## 🚀 PR 요약

검색어 디바운싱을 추가했습니다 

## ✏️ 변경 유형

- [v] feat: 새로운 기능 추가
- [ ] fix: 버그 수정
- [ ] docs: 문서 수정
- [ ] style: 코드 포맷팅 등 스타일 변경
- [ ] refact: 코드 리팩토링
- [ ] test: 테스트 코드 추가/수정
- [ ] chore: 기타 변경사항

## ✅ 체크리스트

- [v] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [ ] 커밋에 관련된 이슈 번호를 포함했습니다.
- [v] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 상세 내용 (선택)

### 작업 사항

src/hooks/useDebounce.ts: 범용적으로 사용할 수 있는 디바운싱 커스텀 훅을 생성했습니다.

src/pages/community/CommunityListPage.tsx: 검색 입력값에 500ms의 디바운싱을 적용했습니다.

이제 사용자가 타이핑하는 동안에는 API 요청이 발생하지 않으며
입력을 멈추고 0.5초가 지난 뒤에만 서버로 검색 요청이 가게 되어 성능과 서버 부하가 개선되었습니다.


