### PR TITLE
feat: 로그인 리다이렉트 변경 작업

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -47,6 +47,9 @@ api.interceptors.request.use(
   }
 )
 
+export const EXTERNAL_LOGIN_URL = 'https://my.ozcodingschool.site/login'
+export const EXTERNAL_SIGNUP_URL = 'https://my.ozcodingschool.site/signup'
+
 // =============================
 // Response 인터셉터
 // =============================
@@ -86,7 +89,7 @@ api.interceptors.response.use(
         
         // 로그인 페이지로 리다이렉트
         if (typeof window !== 'undefined') {
-          window.location.href = '/login'
+          window.location.href = EXTERNAL_LOGIN_URL
         }
         
         return Promise.reject(refreshError)

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,4 +1,6 @@
 // src/components/layout/Header.tsx
+import { EXTERNAL_LOGIN_URL, EXTERNAL_SIGNUP_URL } from '../../api/api'
+
 export default function Header() {
   return (
     <header className="fixed top-0 left-0 z-50 w-full">
@@ -73,14 +75,14 @@ export default function Header() {
           {/* 오른쪽 메뉴 */}
           <div className="flex items-center gap-2 font-[Pretendard] text-[16px] text-gray-500">
             <a
-              href="#"
+              href={EXTERNAL_LOGIN_URL}
               className="hover:text-gray-900 transition-colors duration-200"
             >
               로그인
             </a>
             <span className="text-gray-300">|</span>
             <a
-              href="#"
+              href={EXTERNAL_SIGNUP_URL}
               className="hover:text-gray-900 transition-colors duration-200"
             >
               회원가입

--- a/src/pages/community/CommunityCreatePage.tsx
+++ b/src/pages/community/CommunityCreatePage.tsx
@@ -30,7 +30,7 @@ import {
   ToolbarIndentIcon
 } from '../../components/icons/CustomIcons'
 
-import { api, createCommunityPost, getPresignedUrl, uploadToS3 } from '../../api/api'
+import { EXTERNAL_LOGIN_URL, api, createCommunityPost, getPresignedUrl, uploadToS3 } from '../../api/api'
 
 
 import type { CommunityCategory } from '../../types'
@@ -70,9 +70,9 @@ export default function CommunityCreatePage() {
     useEffect(() => {
     if (!isLoggedIn) {
       alert('로그인이 필요한 서비스입니다.')
-      navigate('/login', { replace: true, state: { from: '/community/new' } })
+      window.location.href = EXTERNAL_LOGIN_URL
     }
-  }, [isLoggedIn, navigate])
+  }, [isLoggedIn])
   
   // --- Data ---
   const [categories, setCategories] = useState<CommunityCategory[]>([])

--- a/src/pages/community/CommunityDetailPage.tsx
+++ b/src/pages/community/CommunityDetailPage.tsx
@@ -9,6 +9,7 @@ import {
   likeCommunityPost,
   unlikeCommunityPost,
   deleteCommunityPost,
+  EXTERNAL_LOGIN_URL,
 } from './../../api/api'
 import { useInfiniteScroll } from './../../hooks'
 import ReactMarkdown from 'react-markdown'
@@ -313,7 +314,7 @@ export default function CommunityDetailPage() {
   const handleLikeToggle = async () => {
     if (!loggedIn) {
       if (window.confirm('로그인이 필요한 기능입니다. 로그인 하시겠습니까?')) {
-        navigate('/login', { state: { from: `/community/${postId}` } })
+        window.location.href = EXTERNAL_LOGIN_URL
       }
       return
     }
@@ -392,7 +393,7 @@ export default function CommunityDetailPage() {
   const handleCommentSubmit = async () => {
     if (!loggedIn) {
       window.alert('로그인이 필요합니다.')
-      navigate('/login', { state: { from: `/community/${postId}` } })
+      window.location.href = EXTERNAL_LOGIN_URL
       return
     }
 

--- a/src/pages/community/CommunityEditPage.tsx
+++ b/src/pages/community/CommunityEditPage.tsx
@@ -30,7 +30,7 @@ import {
   ToolbarIndentIcon
 } from '../../components/icons/CustomIcons'
 
-import { api, createCommunityPost, updateCommunityPost, getCommunityPostDetail, getAccessToken, getPresignedUrl, uploadToS3 } from '../../api/api'
+import { EXTERNAL_LOGIN_URL, api, createCommunityPost, updateCommunityPost, getCommunityPostDetail, getPresignedUrl, uploadToS3 } from '../../api/api'
 import type { CommunityCategory } from '../../types'
 
 function getSelectionInfo(textarea: HTMLTextAreaElement) {
@@ -70,10 +70,9 @@ export default function CommunityEditPage() {
    useEffect(() => {
     if (!isLoggedIn) {
       alert('로그인이 필요한 서비스입니다.')
-      const redirectPath = isEditMode ? `/community/${postId}/edit` : '/community/new'
-      navigate('/login', { replace: true, state: { from: redirectPath } })
+      window.location.href = EXTERNAL_LOGIN_URL
     }
-  }, [isLoggedIn, navigate, isEditMode, postId])
+  }, [isLoggedIn])
   
   // --- Data ---
   const [categories, setCategories] = useState<CommunityCategory[]>([])


### PR DESCRIPTION
## 🚀 PR 요약

로그인 리다이렉트를 외부 URL로 변경하는 작업 완료

## ✏️ 변경 유형

- [V] feat: 새로운 기능 추가
- [ ] fix: 버그 수정
- [ ] docs: 문서 수정
- [ ] style: 코드 포맷팅 등 스타일 변경
- [v] refact: 코드 리팩토링
- [ ] test: 테스트 코드 추가/수정
- [ ] chore: 기타 변경사항

## ✅ 체크리스트

- [v] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [ ] 커밋에 관련된 이슈 번호를 포함했습니다.
- [v] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 상세 내용 (선택)

### 작업 사항

프로그래밍 방식 리다이렉트: 토큰 만료 시 또는 접근 권한이 없는 페이지 접근 시 외부 로그인 페이지로 즉시 이동하도록 수정했습니다.
UI 링크: 헤더의 "로그인" 및 "회원가입" 링크를 외부 해당 URL로 연결했습니다.
상호작용 팝업: 로그인하지 않은 상태에서 좋아요나 댓글을 남기려 할 때 노출되는 확인창을 통해 외부 로그인 페이지로 이동할 수 있도록 구현했습니다.



### 스크린 샷
누르면 가지는 로그인 화면 
<img width="1544" height="977" alt="image" src="https://github.com/user-attachments/assets/4151c6fa-bd27-4e7d-bbf6-0af24fbf73e5" />

<img width="1583" height="944" alt="image" src="https://github.com/user-attachments/assets/38ee8e19-3e7b-48c1-a9c9-7193790923e5" />
