### PR TITLE
fix/ 비회원 좋아요 로그인 페이지 이동

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -17,6 +17,9 @@ import type {
 } from '../types'
 import { useAuthStore } from '../store/index'
 
+export const EXTERNAL_LOGIN_URL = 'https://my.ozcodingschool.site/login'
+export const EXTERNAL_SIGNUP_URL = 'https://my.ozcodingschool.site/signup'
+
 const BASE_URL = import.meta.env.VITE_API_BASE_URL ?? ''
 
 /** axios 인스턴스 (쿠키 인증 대비: withCredentials) */
@@ -46,9 +49,6 @@ api.interceptors.request.use(
     return Promise.reject(error)
   }
 )
-
-export const EXTERNAL_LOGIN_URL = 'https://my.ozcodingschool.site/login'
-export const EXTERNAL_SIGNUP_URL = 'https://my.ozcodingschool.site/signup'
 
 // =============================
 // Response 인터셉터

--- a/src/pages/community/CommunityCreatePage.tsx
+++ b/src/pages/community/CommunityCreatePage.tsx
@@ -70,7 +70,7 @@ export default function CommunityCreatePage() {
     useEffect(() => {
     if (!isLoggedIn) {
       alert('로그인이 필요한 서비스입니다.')
-      window.location.href = EXTERNAL_LOGIN_URL
+      window.location.href = EXTERNAL_LOGIN_URL || 'https://my.ozcodingschool.site/login'
     }
   }, [isLoggedIn])
   

--- a/src/pages/community/CommunityDetailPage.tsx
+++ b/src/pages/community/CommunityDetailPage.tsx
@@ -314,7 +314,7 @@ export default function CommunityDetailPage() {
   const handleLikeToggle = async () => {
     if (!loggedIn) {
       if (window.confirm('로그인이 필요한 기능입니다. 로그인 하시겠습니까?')) {
-        window.location.href = EXTERNAL_LOGIN_URL
+        window.location.href = EXTERNAL_LOGIN_URL || 'https://my.ozcodingschool.site/login'
       }
       return
     }
@@ -393,7 +393,7 @@ export default function CommunityDetailPage() {
   const handleCommentSubmit = async () => {
     if (!loggedIn) {
       window.alert('로그인이 필요합니다.')
-      window.location.href = EXTERNAL_LOGIN_URL
+      window.location.href = EXTERNAL_LOGIN_URL || 'https://my.ozcodingschool.site/login'
       return
     }
 

--- a/src/pages/community/CommunityEditPage.tsx
+++ b/src/pages/community/CommunityEditPage.tsx
@@ -70,7 +70,7 @@ export default function CommunityEditPage() {
    useEffect(() => {
     if (!isLoggedIn) {
       alert('로그인이 필요한 서비스입니다.')
-      window.location.href = EXTERNAL_LOGIN_URL
+      window.location.href = EXTERNAL_LOGIN_URL || 'https://my.ozcodingschool.site/login'
     }
   }, [isLoggedIn])
   


### PR DESCRIPTION
## 🚀 PR 요약

로그인 페이지로 안가지는 (좋아요 누를 시 ) 에러 해결 
## ✏️ 변경 유형

- [ ] feat: 새로운 기능 추가
- [v] fix: 버그 수정
- [ ] docs: 문서 수정
- [ ] style: 코드 포맷팅 등 스타일 변경
- [ ] refact: 코드 리팩토링
- [ ] test: 테스트 코드 추가/수정
- [ ] chore: 기타 변경사항

## ✅ 체크리스트

- [v] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [v] 커밋에 관련된 이슈 번호를 포함했습니다.
- [v] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 상세 내용 (선택)

### 작업 사항

api.ts에서 상수를 최상단으로 옮겨 초기화 문제를 방지했습니다.

각 페이지(Detail, Create, Edit)의 리다이렉트 로직에 하드코딩된
 fallback URL을 추가하여 상수가 비어있더라도 안전하게 외부 로그인 페이지로 이동하도록 보완했습니다.


## 🔗 연관된 이슈

> closes #158 
