### PR TITLE
feat : 카테고리 동기화 작업

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,3 +1,4 @@
 //hooks
 export * from './useInfiniteScroll'
 export * from './useDebounce'
+export * from './useCommunity'

--- a/src/hooks/useCommunity.ts
+++ b/src/hooks/useCommunity.ts
@@ -1,0 +1,16 @@
+import { useQuery } from '@tanstack/react-query'
+import { communityApi } from '../api/api'
+import type { CommunityCategory } from '../types'
+
+/**
+ * 전역적으로 커뮤니티 카테고리 목록을 관리하는 훅입니다.
+ * React Query를 사용하여 데이터 캐싱 및 자동 업데이트를 지원합니다.
+ */
+export function useCategories() {
+  return useQuery<CommunityCategory[]>({
+    queryKey: ['community', 'categories'],
+    queryFn: communityApi.getCategories,
+    staleTime: 1000 * 60 * 5, // 5분 동안은 신선한 데이터로 간주
+    gcTime: 1000 * 60 * 30, // 30분 동안 캐시 유지
+  })
+}

--- a/src/pages/community/CommunityCreatePage.tsx
+++ b/src/pages/community/CommunityCreatePage.tsx
@@ -30,10 +30,8 @@ import {
   ToolbarIndentIcon
 } from '../../components/icons/CustomIcons'
 
-import { EXTERNAL_LOGIN_URL, api, createCommunityPost, getPresignedUrl, uploadToS3 } from '../../api/api'
-
-
-import type { CommunityCategory } from '../../types'
+import { EXTERNAL_LOGIN_URL, createCommunityPost, getPresignedUrl, uploadToS3 } from '../../api/api'
+import { useCategories } from '../../hooks'
 
 function getSelectionInfo(textarea: HTMLTextAreaElement) {
   const start = textarea.selectionStart
@@ -75,7 +73,7 @@ export default function CommunityCreatePage() {
   }, [isLoggedIn])
   
   // --- Data ---
-  const [categories, setCategories] = useState<CommunityCategory[]>([])
+  const { data: categories = [] } = useCategories()
   const [categoryId, setCategoryId] = useState<number | null>(null)
   const [title, setTitle] = useState('')
   const [content, setContent] = useState('')
@@ -102,17 +100,6 @@ export default function CommunityCreatePage() {
   const [historyIndex, setHistoryIndex] = useState(0)
 
 
-  useEffect(() => {
-    async function fetchCategories() {
-      try {
-        const res = await api.get<CommunityCategory[]>('/api/v1/posts/categories')
-        setCategories(res.data)
-      } catch (error) {
-        console.error('카테고리 불러오기 실패:', error)
-      }
-    }
-    fetchCategories()
-  }, [])
 
 
   useEffect(() => {

--- a/src/pages/community/CommunityEditPage.tsx
+++ b/src/pages/community/CommunityEditPage.tsx
@@ -30,8 +30,8 @@ import {
   ToolbarIndentIcon
 } from '../../components/icons/CustomIcons'
 
-import { EXTERNAL_LOGIN_URL, api, createCommunityPost, updateCommunityPost, getCommunityPostDetail, getPresignedUrl, uploadToS3 } from '../../api/api'
-import type { CommunityCategory } from '../../types'
+import { EXTERNAL_LOGIN_URL, createCommunityPost, updateCommunityPost, getCommunityPostDetail, getPresignedUrl, uploadToS3 } from '../../api/api'
+import { useCategories } from '../../hooks'
 
 function getSelectionInfo(textarea: HTMLTextAreaElement) {
   const start = textarea.selectionStart
@@ -75,7 +75,7 @@ export default function CommunityEditPage() {
   }, [isLoggedIn])
   
   // --- Data ---
-  const [categories, setCategories] = useState<CommunityCategory[]>([])
+  const { data: categories = [] } = useCategories()
   const [categoryId, setCategoryId] = useState<number | null>(null)
   const [title, setTitle] = useState('')
   const [content, setContent] = useState('')
@@ -103,18 +103,6 @@ export default function CommunityEditPage() {
   const debounceTimerRef = useRef<NodeJS.Timeout | null>(null)
 
 
-  // 카테고리 목록 불러오기
-  useEffect(() => {
-    async function fetchCategories() {
-      try {
-        const res = await api.get<CommunityCategory[]>('/api/v1/posts/categories')
-        setCategories(res.data)
-      } catch (error) {
-        console.error('카테고리 불러오기 실패:', error)
-      }
-    }
-    fetchCategories()
-  }, [])
 
   // 수정 모드일 때 기존 게시글 데이터 불러오기
   useEffect(() => {

--- a/src/pages/community/CommunityListPage.tsx
+++ b/src/pages/community/CommunityListPage.tsx
@@ -1,11 +1,10 @@
 import { useMemo, useState, useRef, useEffect } from 'react'
-import { useQuery } from '@tanstack/react-query'
 import { useNavigate } from 'react-router-dom'
 import { motion } from 'framer-motion'
 import CommunityListItem from '../../components/community/list/CommunityListItem'
 import CommunitySearchBar from '../../components/community/list/CommunitySearchBar'
 import { communityApi } from '../../api/api'
-import { useInfiniteScroll, useDebounce } from '../../hooks'
+import { useInfiniteScroll, useDebounce, useCategories } from '../../hooks'
 import type {
   CommunityCategory,
   CommunityPostListItem,
@@ -140,10 +139,7 @@ export default function CommunityListPage() {
     return () => document.removeEventListener('mousedown', onDocDown)
   }, [sortOpen])
 
-  const { data: categoriesRaw } = useQuery({
-    queryKey: ['community', 'categories'],
-    queryFn: communityApi.getCategories,
-  })
+  const { data: categoriesRaw } = useCategories()
 
   const categories: CommunityCategory[] = useMemo(() => {
     const server = categoriesRaw ?? []


### PR DESCRIPTION
## 🚀 PR 요약

카테고리 동기화 완료 

## ✏️ 변경 유형

- [v] feat: 새로운 기능 추가
- [ ] fix: 버그 수정
- [ ] docs: 문서 수정
- [ ] style: 코드 포맷팅 등 스타일 변경
- [v] refact: 코드 리팩토링
- [ ] test: 테스트 코드 추가/수정
- [ ] chore: 기타 변경사항

## ✅ 체크리스트

- [ ] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [ ] 커밋에 관련된 이슈 번호를 포함했습니다.
- [v] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 상세 내용 (선택)

### 작업 사항

커뮤니티 페이지(목록, 작성, 수정)가 React Query 기반의 공통 훅(useCategories)을 사용하여 데이터를 가져옵니다. 
이를 통해 어드민 등 다른 곳에서 카테고리가 추가되더라도, 
별도의 새로고침 없이도 모든 페이지에서 동일하고 최신 상태의 카테고리 목록을 확인할 수 있습니다.


useCommunity.ts: 전역 캐싱을 지원하는 카테고리 조회 훅 생성

CommunityListPage, CommunityCreatePage, CommunityEditPage: 공통 훅 적용 및 중복 로직 제거
변경 사항 요약:

