### PR TITLE
refact/커뮤니티 검색 옵션에서 내용 항목 제거

### DIFF
--- a/src/components/community/list/CommunitySearchBar.tsx
+++ b/src/components/community/list/CommunitySearchBar.tsx
@@ -82,7 +82,6 @@ type Props = {
 
 const FILTER_ITEMS: Array<{ key: SearchFilterOption; label: string }> = [
   { key: 'title', label: '제목' },
-  { key: 'content', label: '내용' },
   { key: 'nickname', label: '작성자' },
 ]
 


### PR DESCRIPTION
## 🚀 PR 요약

> 커뮤니티 검색 옵션에서 "내용" 항목을 제거했습니다

## ✏️ 변경 유형

- [ ] feat: 새로운 기능 추가
- [ ] fix: 버그 수정
- [ ] docs: 문서 수정
- [ ] style: 코드 포맷팅 등 스타일 변경
- [x] refact: 코드 리팩토링
- [ ] test: 테스트 코드 추가/수정
- [ ] chore: 기타 변경사항

## ✅ 체크리스트

- [x] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [x] 커밋에 관련된 이슈 번호를 포함했습니다.
- [x] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 상세 내용 (선택)

### 작업 사항

- 검색 기준을 제목 / 작성자로 제한했습니다.

### 스크린 샷

> 화면을 새로 추가했거나 이전과 변화가 있을 경우 추가

## 🔗 연관된 이슈

> closes #179

